### PR TITLE
Add quicktype type checker

### DIFF
--- a/quicktype.yue
+++ b/quicktype.yue
@@ -18,6 +18,7 @@ type_checker = (type_spec) ->
     checker = parsed_type\checker!
 
     type_checkers[type_spec] = checker
+    validate checker
     print "got checker:\n#{repr checker}"
     checker
 
@@ -340,7 +341,7 @@ class List
       loop_start = #prog
       [] = C_GET_FIELD
       [] = C_JMP_IF_NIL
-      [] = 10101010
+      [] = LABEL_PLACEHOLDER
       loop_exit_jump_index = #prog
       @elem_type\checker prog
       [] = C_POP
@@ -456,6 +457,13 @@ C_GET_FIELD = <tostring>: => '<field>'
 C_INCR = <tostring>: => '<incr>'
 C_JMP = <tostring>: => '<jmp>'
 C_JMP_IF_NIL = <tostring>: => '<jnil>'
+
+LABEL_PLACEHOLDER = <tostring>: => '<LABEL-PLACEHOLDER>'
+
+validate = (check_prog) ->
+  for instruction in *check_prog
+    if instruction == LABEL_PLACEHOLDER
+      error "unresolved placeholder in check program:\n#{repr check_prog}"
 
 value_stack_size = 0
 value_stack = {}

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -690,7 +690,7 @@ class Function using Is
       [] = ') -> '
       if #@return_types == 1
         if @remainder_return_type?
-          [] = tostring remainder_return_type
+          [] = tostring @remainder_return_type
           [] = '...'
         else
           [] = tostring @return_types[1]

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -18,13 +18,48 @@ type_checkers = {}
 type_checker = (type_spec) ->
   type_checkers[type_spec] ?? do
     -- Slow path: parse and generate checker
-    parsed_type = parse type_spec
-    checker = parsed_type\checker!\build!
+    checker = (parse type_spec)\checker!\build!
 
     type_checkers[type_spec] = checker
     if DEBUG
       print "got checker:\n\t#{checker_program_repr checker}"
     checker
+
+export F = (type_spec, fn) ->
+  if not type_spec?
+    error 'cannot typecheck: no type spec provided'
+  if 'function' != type fn
+    error 'cannot typecheck: no function provided'
+
+  fn_type = function_type type_spec
+
+  return_types = fn_type\return_checkers!
+  check_returns = (...) ->
+    n_return_values = select '#', ...
+    if #return_types < n_return_values
+      error 'function returned too many values'
+    for i = 1, #return_types
+      check return_types[i], select i, ...
+    ...
+
+  param_types = fn_type\param_checkers!
+  (...) ->
+    if #param_types < select '#', ...
+      error 'function passed too many arguments'
+    for i = 1, #param_types
+      check param_types[i], select i, ...
+    check_returns fn ...
+
+function_types = {}
+function_type = (type_spec) ->
+  function_types[type_spec] ?? do
+    -- Slow path: parse type spec
+    parsed_type = parse type_spec
+    if parsed_type.<class>.__name != 'Function'
+      error "cannot typecheck: expected a function type"
+
+    function_types[type_spec] = parsed_type
+    parsed_type
 
 parse = (type_spec) ->
   type_spec_parser = TypeSpecParser Lexer type_spec
@@ -478,6 +513,26 @@ class Mapping
 
 class Function
   new: (@param_types, @return_types) =>
+    @_param_checkers = nil
+    @_return_checkers = nil
+
+  param_checkers: =>
+    if param_checkers = @_param_checkers
+      return param_checkers
+    param_checkers = with {}
+      for param_type in *@param_types
+        [] = param_type\checker!\build!
+    @_param_checkers = param_checkers
+    param_checkers
+
+  return_checkers: =>
+    if return_checkers = @_return_checkers
+      return return_checkers
+    return_checkers = with {}
+      for return_type in *@return_types
+        [] = return_type\checker!\build!
+    @_return_checkers = return_checkers
+    return_checkers
 
   __tostring: =>
     table.concat with {}
@@ -590,7 +645,6 @@ instruction_counts = {}
 
 export MAX_CHECKER_DEPTH = 1000
 check = (check_prog, value, root=true) ->
-
   if root
     -- Prime stack.
     stack_size = 1
@@ -958,6 +1012,40 @@ spec ->
       declare_type 'MutuallyRecursive2', 'MutuallyRecursive1'
       expect_that (-> T 'MutuallyRecursive1', nil), no_errors!
       expect_that (-> T 'MutuallyRecursive1', 'asdf'), errors matches 'type checker recursed too many times'
+
+  describe 'F', ->
+    it 'requires two arguments', ->
+      expect_that (-> F!), errors matches 'cannot typecheck: no type spec provided'
+      expect_that (-> F '() -> nil'), errors matches 'cannot typecheck: no function provided'
+      expect_that (-> F '() -> nil', 'interloper'), errors matches 'cannot typecheck: no function provided'
+
+    it 'returns its second argument', ->
+      f = F '(number, number) -> number', (a, b) -> a + b
+      expect_that (f 1, 2), eq 3
+
+    it 'accepts nil returns', ->
+      expect_that (-> (F '() -> nil', ->)!), no_errors!
+
+    it 'accepts absent optional arguments', ->
+      expect_that (-> (F '() -> ?string', ->)!), no_errors!
+
+    it 'accepts absent optional retunsr', ->
+      expect_that (-> (F '() -> nil', ->)!), no_errors!
+
+    it 'rejects non-function types', ->
+      expect_that (-> F '{}', ->), errors matches 'cannot typecheck: expected a function type'
+
+    it 'rejects incorrect-type arguments', ->
+      expect_that (-> (F '(string) -> table', ->) 123), errors matches 'incorrect type: expected string but got number'
+
+    it 'rejects extra arguments', ->
+      expect_that (-> (F '(string) -> table', ->) 'a', 'b'), errors matches 'function passed too many arguments'
+
+    it 'rejects incorrect-type return values', ->
+      expect_that (-> (F '(table) -> string', ->) {}), errors matches 'incorrect type: expected string but got number'
+
+    it 'rejects extra return arguments', ->
+      expect_that (-> (F '() -> string', -> 'a', 'b')!), errors matches 'function returned too many values'
 
   describe 'stats', ->
     it 'has the correct type', ->

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -10,8 +10,8 @@ export T = (type_spec, value) ->
   checker = type_checker type_spec
   check checker, value
 
-DEBUG = false
-COLLECT_STATS = false
+export DEBUG = false
+export COLLECT_STATS = false
 
 type_checkers = {}
 type_checker = (type_spec) ->

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -7,7 +7,9 @@ export T = (type_spec, value) ->
     error 'cannot typecheck: no type spec provided'
 
   checker = type_checker type_spec
-  check checker, value
+  err = check checker, value
+  if err?
+    error err -- , 2
   value
 
 export DEBUG = false
@@ -34,12 +36,16 @@ export F = (type_spec, fn) ->
   n_return_types = #return_types
   check_returns = (...) ->
     for i = 1, n_return_types
-      check return_types[i], select i, ...
+      err = check return_types[i], select i, ...
+      if err?
+        error err --, 2
     for i = n_return_types+1, select '#', ...
       checker = return_types[i]
       if not checker?
         error 'function returned too many values'
-      check checker, select i, ...
+      err = check checker, select i, ...
+      if err?
+        error err --, 2
 
     ...
 
@@ -47,12 +53,16 @@ export F = (type_spec, fn) ->
   n_param_types = #param_types
   (...) ->
     for i = 1, n_param_types
-      check param_types[i], select i, ...
+      err = check param_types[i], select i, ...
+      if err?
+        error err --, 2
     for i = n_param_types+1, select '#', ...
       checker = param_types[i]
       if not checker?
         error 'function given too many arguments'
-      check checker, select i, ...
+      err = check checker, select i, ...
+      if err?
+        error err --, 2
 
     check_returns fn ...
 
@@ -450,8 +460,6 @@ known_primitives =
   table: true
   thread: true
 named_type = (name) ->
-  if not name.match?
-    error repr name
   if known_primitives[name]?
     Primitive name
   else if name == 'any'
@@ -844,6 +852,24 @@ union_bail_jumps = {}
 root_union = nil
 num_running_checkers = 0
 instruction_counts = {}
+macro check_error = (msg) ->
+  lines = with {}
+    [] = 'msg = if num_unions == 0'
+    [] = "  #{msg}"
+    [] = 'else'
+    [] = '  nil'
+
+    [] = 'new_size = union_depths[num_unions] ?? 0'
+    [] = 'for i = new_size + 1, stack_size'
+    [] = '  stack[i] = nil'
+    [] = 'stack_size = new_size'
+
+    [] = 'if num_unions == 0'
+    [] = '  return msg'
+    [] = 'print "BAILING to #{union_bail_jumps[num_unions]}"'
+    [] = 'pc = union_bail_jumps[num_unions] - 2'
+    [] = 'bailing = true'
+  table.concat lines, '\n'
 check = (check_prog, value, root=true) ->
   if root
     -- Prime stack.
@@ -854,28 +880,13 @@ check = (check_prog, value, root=true) ->
   initial_num_running_checkers = num_running_checkers
 
   if num_running_checkers >= MAX_CHECKER_DEPTH
-    error "type checker recursed too many times (#{num_running_checkers} times). If this is okay, increase the MAX_CHECKER_DEPTH"
+    return "type checker recursed too many times (#{num_running_checkers} times). If this is okay, increase the MAX_CHECKER_DEPTH"
 
   if DEBUG
     print "running checker:\n\t#{checker_program_repr check_prog}"
   with check_prog
     local pc
     bailing = false
-    check_error = (msg) ->
-      -- TODO(kcza): make this a macro!
-      if num_unions == 0 and 'function' == type msg
-        msg = msg! -- Resolve before touching stack.
-
-      new_size = union_depths[num_unions] ?? 0
-      for i = new_size + 1, stack_size
-        stack[i] = nil
-      stack_size = new_size
-
-      if num_unions == 0
-        error msg
-      print "BAILING to #{union_bail_jumps[num_unions]}"
-      pc = union_bail_jumps[num_unions] - 2
-      bailing = true
 
     pc = -1
     while true
@@ -907,21 +918,18 @@ check = (check_prog, value, root=true) ->
           ty = type stack[stack_size]
           arg = [pc + 1]
           if ty != arg
-            print 'OH NO'
-            print num_unions
-            check_error -> "incorrect type: expected #{arg} but got #{ty}"
-            print 'OH YEAH'
+            $check_error "incorrect type: expected #{arg} but got #{ty}"
         when C_ASSERT_TRUTHY
           if not stack[stack_size]
-            check_error -> "incorrect type: expected a truthy value but got #{stack[stack_size]}"
+            $check_error "incorrect type: expected a truthy value but got #{stack[stack_size]}"
         when C_ASSERT_LEN
           actual_len = #stack[stack_size-1]
           counted_len = stack[stack_size]
           if counted_len != actual_len
-            check_error "incorrect type: expected array but got table"
+            $check_error "incorrect type: expected array but got table"
         when C_ASSERT_EQ
           if stack[stack_size] != [pc + 1]
-            check_error -> "incorrect type: expected #{type [pc + 1]} #{repr [pc + 1]}"
+            $check_error "incorrect type: expected #{type [pc + 1]} #{repr [pc + 1]}"
         when C_GET_FIELD
           stack_size += 1
           stack[stack_size] = stack[stack_size-2][stack[stack_size-1]]
@@ -945,33 +953,27 @@ check = (check_prog, value, root=true) ->
           arg = [pc + 1]
           checker = type_checkers[arg]
           if not checker?
-            error "cannot typecheck #{arg}: type not defined"
+            return "cannot typecheck #{arg}: type not defined"
 
           num_running_checkers += 1
-          recovered_err = nil
-          try -- TODO(kcza): remove this try
-            recovered_err = check checker, nil, false
-          catch err
-            recovered_err = err
-            print 'RECOVERED'
+          err = check checker, nil, false
           num_running_checkers -= 1
 
-          if recovered_err?
+          if err?
             if num_unions == 0
-              error recovered_err
+              return err
+
+            bailing = true
             pc = union_bail_jumps[num_unions] - 2
         when C_CLEAR_BAILING
           bailing = false
         when C_SET_UNION_BAIL_TARGET
-          -- TODO(kcza): CHECK VIA USER TYPES!
           union_bail_jumps[num_unions] = [pc + 1]
         when C_PUSH_UNION_CTX
           num_unions += 1
           union_depths[num_unions] = #stack
           if num_unions == 1
             root_union = [pc + 1]
-            print "set root union to #{[pc + 1]}; #{[pc]}"
-          print "ROOT UNION IS #{root_union}"
         when C_POP_UNION_CTX
           union_bail_jumps[num_unions] = nil
           union_depths[num_unions] = nil
@@ -979,9 +981,9 @@ check = (check_prog, value, root=true) ->
 
           if bailing
             if num_unions == 0
-              check_error "incorrect type: expected #{root_union} but got #{type stack[stack_size]}"
+              $check_error "incorrect type: expected #{root_union} but got #{type stack[stack_size]}"
             else
-              check_error! -- Unwind.
+              $check_error! -- Unwind.
 
           if num_unions == 0
             root_union = nil

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -20,8 +20,6 @@ type_checker = (type_spec) ->
     checker = (parse type_spec)\checker!\build!
 
     type_checkers[type_spec] = checker
-    if DEBUG
-      print "got checker:\n\t#{checker_program_repr checker}"
     checker
 
 export F = (type_spec, fn) ->
@@ -838,6 +836,8 @@ check = (check_prog, value, root=true) ->
   if num_running_checkers >= MAX_CHECKER_DEPTH
     error "type checker recursed too many times (#{num_running_checkers} times). If this is okay, increase the MAX_CHECKER_DEPTH"
 
+  if DEBUG
+    print "running checker:\n\t#{checker_program_repr check_prog}"
   with check_prog
     local pc = -1
     while true

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -440,7 +440,30 @@ class Mapping
     "{#{@in_type} -> #{@out_type}}"
 
   checker: (prog={}) =>
-    error 'todo'
+    with prog
+      [] = C_ASSERT_PRIMITIVE
+      [] = 'table'
+      [] = C_PUSH
+      [] = V_NIL
+      [] = C_NEXT
+
+      loop_start = #prog + 1
+      [] = C_JMP_IF_NIL
+      loop_exit_jump_index = #prog + 1
+      [] = LABEL_PLACEHOLDER
+
+      @out_type\checker prog
+      [] = C_POP
+      @in_type\checker prog
+
+      [] = C_NEXT
+      [] = C_JMP
+      [] = loop_start
+
+      [loop_exit_jump_index] = #prog + 1
+      [] = C_POP
+      [] = C_POP
+
 
 class Function
   new: (@param_types, @return_types) =>
@@ -479,8 +502,10 @@ C_ASSERT_PRIMITIVE = <tostring>: => '<assert-primitive>'
 C_ASSERT_LEN = <tostring>: => '<assert-len>'
 C_GET_FIELD = <tostring>: => '<field>'
 C_INCR = <tostring>: => '<incr>'
+C_NEXT = <tostring>: => '<next>'
 C_JMP = <tostring>: => '<jmp>'
 C_JMP_IF_NIL = <tostring>: => '<jnil>'
+V_NIL = <tostring>: => 'nil'
 
 LABEL_PLACEHOLDER = <tostring>: => '<LABEL-PLACEHOLDER>'
 
@@ -504,6 +529,8 @@ check = (check_prog, value) ->
         when C_PUSH
           pc += 1
           value = [pc]
+          if value == V_NIL
+            value = nil
           value_stack_size += 1
           value_stack[value_stack_size] = value
         when C_POP
@@ -524,6 +551,13 @@ check = (check_prog, value) ->
           value_stack[value_stack_size] = value_stack[value_stack_size-2][value_stack[value_stack_size-1]]
         when C_INCR
           value_stack[value_stack_size] += 1
+        when C_NEXT
+          tab = value_stack[value_stack_size-1]
+          idx = value_stack[value_stack_size]
+          next_idx, value = next tab, idx
+          value_stack[value_stack_size] = next_idx
+          value_stack_size += 1
+          value_stack[value_stack_size] = value
         when C_JMP
           pc = [pc + 1] - 1
         when C_JMP_IF_NIL
@@ -723,6 +757,14 @@ spec ->
       expect_that (-> T '(number, boolean, string)', {}), errors matches 'incorrect type: expected number but got nil'
       expect_that (-> T '(number, boolean, string)', {123}), errors matches 'incorrect type: expected boolean but got nil'
       expect_that (-> T '(number, boolean, string)', {'interloper'}), errors matches 'incorrect type: expected number but got string'
+
+    it 'checks mappings', ->
+      expect_that (-> T '{string -> number}', {}), no_errors!
+      expect_that (-> T '{number -> string}', {'hello', [10]: 'world'}), no_errors!
+      expect_that (-> T '{{boolean -> number} -> {string -> thread}}', {[{[true]: 123}]: {asdf: coroutine.create ->}}), no_errors!
+
+      expect_that (-> T '{number -> string}', {123}), errors matches 'incorrect type: expected string but got number'
+      expect_that (-> T '{number -> string}', {'hello', 'world', 'foo', 'bar', 'baz', 123}), errors matches 'incorrect type: expected string but got number'
 
     it 'checks structs', ->
       expect_that (-> T '{}', {}), no_errors!

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -145,6 +145,8 @@ class TypeSpecParser extends Parser
     handle_optional @select
       * token: T_NAME
         action: @\parse_named_type
+      * token: T_STRING
+        action: @\parse_string_type
       * token: T_BRACKET_OPEN
         action: @\parse_array
       * token: T_PAREN_OPEN
@@ -154,6 +156,9 @@ class TypeSpecParser extends Parser
 
   parse_named_type: =>
     named_type @expect T_NAME
+
+  parse_string_type: =>
+    StringType @expect T_STRING
 
   parse_array: =>
     {_, elem_type, _} = @sequence
@@ -253,6 +258,7 @@ T_COLON = <tostring>: => "':'"
 T_ARROW = <tostring>: => "'->'"
 T_QUESTION = <tostring>: => "'?'"
 T_NAME = <tostring>: => "<name>"
+T_STRING = <tostring>: => "<string>"
 
 class Lexer
   new: (type_spec) =>
@@ -285,6 +291,8 @@ class Lexer
           T_QUESTION, nil, #match
         else if name = type_spec\match '^([a-zA-Z_][a-zA-Z0-9_]*)', @index
           T_NAME, name, #name
+        else if string = type_spec\match [[^"([^"]*)"]], @index
+          T_STRING, string, #string + 2
         else
           error "unrecognised character '#{type_spec\sub @index, @index}' in type spec '#{type_spec}"
 
@@ -380,6 +388,17 @@ class UserType
         \push_building @
         parsed_user_type\checker checker_builder
         \pop_building @
+
+class StringType
+  new: (@content) =>
+
+  __tostring: =>
+    "\"#{@content}\""
+
+  checker: (checker_builder=CheckerBuilder!) =>
+    with checker_builder
+      \add C_ASSERT_PRIMITIVE, 'string'
+      \add C_ASSERT_EQ, @content
 
 class Optional
   new: (@inner_type) =>
@@ -618,6 +637,7 @@ C_POP = <tostring>: => '<pop>'
 C_ASSERT_PRIMITIVE = <tostring>: => '<assert-primitive>'
 C_ASSERT_TRUTHY = <tostring>: => '<assert-truthy>'
 C_ASSERT_LEN = <tostring>: => '<assert-len>'
+C_ASSERT_EQ = <tostring>: => '<assert-eq>'
 C_GET_FIELD = <tostring>: => '<field>'
 C_INCR = <tostring>: => '<incr>'
 C_DECR = <tostring>: => '<decr>'
@@ -700,6 +720,9 @@ check = (check_prog, value, root=true) ->
           counted_len = stack[stack_size]
           if counted_len != actual_len
             check_error "incorrect type: expected array but got table"
+        when C_ASSERT_EQ
+          if stack[stack_size] != [pc + 1]
+            check_error "incorrect type: expected #{type [pc + 1]} #{repr [pc + 1]}"
         when C_GET_FIELD
           stack_size += 1
           stack[stack_size] = stack[stack_size-2][stack[stack_size-1]]
@@ -791,6 +814,12 @@ spec ->
           Symbol T_NAME, simple_type
         }
 
+    it 'emits string types', ->
+      expect_that (tokens '"hello" "world"'), deep_eq {
+        Symbol T_STRING, 'hello'
+        Symbol T_STRING, 'world'
+      }
+
     it 'emits strucural tokens', ->
       expect_that (tokens '(),{}[]:->?'), deep_eq {
         Symbol T_PAREN_OPEN
@@ -846,6 +875,9 @@ spec ->
 
       it 'accepts user types', ->
         expect_that (parse 'UserType'), deep_eq UserType 'UserType'
+
+      it 'accepts string types', ->
+        expect_that (parse '"hello"'), deep_eq StringType 'hello'
 
       it 'rejects unknown primitives', ->
         expect_that (-> parse 'user'), errors matches [[cannot use 'user' as user type name: name must start with an uppercase letter]]
@@ -917,6 +949,10 @@ spec ->
       expect_that (-> T 'nil', 123), errors matches 'incorrect type: expected nil but got number'
       expect_that (-> T 'number', nil), errors matches 'incorrect type: expected number but got nil'
       expect_that (-> T 'string', 123), errors matches 'incorrect type: expected string but got number'
+
+    it 'checks string types', ->
+      expect_that (-> T '"hello"', 'hello'), no_errors!
+      expect_that (-> T '"hello"', 'world'), errors matches "incorrect type: expected string 'hello'"
 
     it 'checks optionals', ->
       expect_that (-> T '?number', nil), no_errors!

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -1,92 +1,142 @@
 local *
 
-import spec from require 'spec'
+import spec, repr from require 'spec'
 
 type_checkers = {}
 
-typed = (type_spec, value) ->
+export typed = (type_spec, value) ->
   if not type_spec?
     error 'cannot typecheck: no type spec provided'
 
+  checker = type_checkers[type_spec] ?? do
+    checker = type_checker type_spec
+    type_checkers[type_spec] = checker
+    checker
+  error 'todo'
   -- checker_steps = type_checkers[type_spec] ?? do
   --   program = generate_checker_program type_spec
   --   type_checkers[type_spec] = program
   --   program
-  checker = type_checker type_spec
-
+  -- checker = type_checker type_spec
   -- print (require 'spec').repr checker
 
-type_checkers = {}
-type_checker = (type_spec) ->
-  with {}
-    -- stack = {}
-    lexer = Lexer type_spec
-    -- print type lexer!
-    -- token_type, token = coroutine.resume lexer
-    token_type, token = lexer\next!
-    while token?
-      print token_type, token
-      token_type, token = lexer\next!
-    -- for token_type, token in
-    --   print token_type, token
-    -- idx = 1
-    -- if named_type = (type_spec\sub idx)\match '^([0-9]+)'
-    --   steps = type_checkers[named_type]
-    --   if not steps?
-    --     error "cannot typecheck: unknown type '#{named_type}'"
-    --   for step in *steps
-    --     [] = step
-    -- else if (type_spec\sub i)\match '^('
-    --   error 'tuples and functions not yet supported'
-    -- else if (type_spec )
+-- Non termianls
+NT_TYPE_SPEC = <tostring>: => "type_spec"
+NT_FUNC_SPEC = <tostring>: => "func_spec"
+NT_NONFUNC_SPEC = <tostring>: => "nonfunc_spec"
+NT_LIST = <tostring>: => "list"
 
-PAREN_OPEN = <tostring>: => "paren_open"
-PAREN_CLOSE = <tostring>: => "paren_close"
-BRACE_OPEN = <tostring>: => "brace_open"
-BRACE_CLOSE = <tostring>: => "brace_close"
-BRACKET_OPEN = <tostring>: => "bracket_close"
-BRACKET_CLOSE = <tostring>: => "bracket_close"
-COMMA = <tostring>: => "comma"
-ARROW = <tostring>: => "arrow"
-NAME = <tostring>: => "name"
+-- Terminals
+T_PAREN_OPEN = <tostring>: => "<paren_open>"
+T_PAREN_CLOSE = <tostring>: => "<paren_close>"
+T_BRACE_OPEN = <tostring>: => "<brace_open>"
+T_BRACE_CLOSE = <tostring>: => "<brace_close>"
+T_BRACKET_OPEN = <tostring>: => "<bracket_close>"
+T_BRACKET_CLOSE = <tostring>: => "<bracket_close>"
+T_COMMA = <tostring>: => "<comma>"
+T_ARROW = <tostring>: => "<arrow>"
+T_NAME = <tostring>: => "<name>"
+
+type_checker = (type_spec) ->
+  type_spec_parser = Parser
+    * produces: NT_TYPE_SPEC
+      patterns:
+        * { NT_NONFUNC_SPEC }
+    * produces: NT_NONFUNC_SPEC
+      patterns:
+        * { T_NAME }
+        * { NT_LIST }
+    * produces: NT_LIST
+      patterns:
+        * { T_BRACKET_OPEN, NT_TYPE_SPEC, T_BRACKET_CLOSE }
+  type_spec_parser\parse type_spec
+  {}
+
+class Parser
+  new: (raw_rules) =>
+    @rules = with {}
+      for { :produces, :patterns } in *raw_rules
+        for pattern in *patterns
+          [] = { :produces, :pattern }
+    @stack = nil
+
+  parse: (type_spec) =>
+    lexer = Lexer type_spec
+
+    @stack = {}
+    for token in lexer.tokens
+      print "stack is #{repr @stack}"
+      reduced = false
+      for rule in *@rules
+        if @try_reduce rule
+          reduced = true
+          break
+      if not reduced
+        @shift token
+  
+  shift: (token) =>
+    @stack[] = token
+    print "shifted #{repr token}"
+
+  try_reduce: (rule) =>
+    { :produces, :pattern } = rule
+
+    -- Check reduction possible
+    if #@stack < #pattern
+      print "! no reduction: too short: #{repr pattern}"
+      return false
+    for i = 0, #pattern - 1
+      print "! no reduction: mismatch: #{repr pattern}"
+      if @stack[#@stack - i].type != pattern[i]
+        return false
+
+    -- Reduce.
+    for i = 1, #pattern
+      @stack[#@stack] = nil
+    @stack[] = token
+    print "reduced #{produces} <- #{repr pattern}"
+    true
+
 class Lexer
   new: (type_spec) =>
+    print "making lexer for #{repr type_spec}"
+
     @done = false
     @peeked = nil
     @tokens = coroutine.wrap ->
       original_type_spec = type_spec
       while #type_spec > 0
-        token_type, value = if whitespace = type_spec\match '^[ \t\r\n]'
+        type, value = if whitespace = type_spec\match '^[ \t\r\n]'
           nil, whitespace
         else if type_spec\match '^%('
-          PAREN_OPEN, '('
+          T_PAREN_OPEN, '('
         else if type_spec\match '^%)'
-          PAREN_CLOSE, ')'
+          T_PAREN_CLOSE, ')'
         else if type_spec\match '^,'
-          COMMA, ','
+          T_COMMA, ','
         else if type_spec\match '^{'
-          BRACE_OPEN, '{'
+          T_BRACE_OPEN, '{'
         else if type_spec\match '^}'
-          BRACE_CLOSE, '}'
+          T_BRACE_CLOSE, '}'
         else if type_spec\match '^%['
-          BRACKET_OPEN, '['
+          T_BRACKET_OPEN, '['
         else if type_spec\match '^]'
-          BRACKET_CLOSE, ']'
+          T_BRACKET_CLOSE, ']'
         else if type_spec\match '^->'
-          ARROW, '->'
+          T_ARROW, '->'
         else if name = type_spec\match '^([a-zA-Z_][a-zA-Z0-9_]*)'
-          NAME, name
+          T_NAME, name
         else
           error "unrecognised character '#{type_spec\sub 1, 1}' in type spec '#{original_type_spec}"
 
         type_spec = type_spec\sub #value + 1
-        switch token_type
+        switch type
           when nil
             continue -- continue
-          when NAME
-            coroutine.yield { :token_type, :value }
+          when T_NAME
+            coroutine.yield { :type, :value }
           else
-            coroutine.yield { :token_type }
+            coroutine.yield { :type }
 
   peek: =>
     if @done
@@ -111,14 +161,22 @@ class Lexer
     else
       @tokens!
 
-declare_type = (name, type_spec) ->
-  error 'todo'
+export declare_type = (name, type_spec) ->
+  first_char = name\sub 1, 1
+  if first_char\upper! != first_char
+    error "cannot declare type '#{name}': custom types must start with uppercase"
+  if type_checkers[name]?
+    error "cannot redefine type '#{name}'"
+  type_checkers[name] = type_checker name
+
+export deactivate = ->
+  typed = (_, fn) -> fn
 
 spec ->
   import assert_that, expect_that, describe, it, matchers from require 'spec'
   import anything, deep_eq, eq, errors, match, matches, no_errors from matchers
 
-  describe 'lex', ->
+  describe 'Lexer', ->
     tokens = (raw) ->
       with {}
         for token in (Lexer raw).tokens
@@ -132,28 +190,28 @@ spec ->
         * type ""
       for simple_type in *simple_types
         expect_that (tokens simple_type), deep_eq {
-          { token_type: NAME, value: simple_type },
+          { type: T_NAME, value: simple_type },
         }
 
     it 'emits strucural tokens', ->
       expect_that (tokens '(),{}[]->'), deep_eq {
-        { token_type: PAREN_OPEN },
-        { token_type: PAREN_CLOSE },
-        { token_type: COMMA },
-        { token_type: BRACE_OPEN },
-        { token_type: BRACE_CLOSE },
-        { token_type: BRACKET_OPEN },
-        { token_type: BRACKET_CLOSE },
-        { token_type: ARROW },
+        { type: T_PAREN_OPEN },
+        { type: T_PAREN_CLOSE },
+        { type: T_COMMA },
+        { type: T_BRACE_OPEN },
+        { type: T_BRACE_CLOSE },
+        { type: T_BRACKET_OPEN },
+        { type: T_BRACKET_CLOSE },
+        { type: T_ARROW },
       }
 
     it 'ignores whitespace', ->
       expect_that (tokens ' (\tstring\r)\n-> string '), deep_eq {
-        { token_type: PAREN_OPEN },
-        { token_type: NAME, value: "string" },
-        { token_type: PAREN_CLOSE },
-        { token_type: ARROW },
-        { token_type: NAME, value: "string" },
+        { type: T_PAREN_OPEN },
+        { type: T_NAME, value: "string" },
+        { type: T_PAREN_CLOSE },
+        { type: T_ARROW },
+        { type: T_NAME, value: "string" },
       }
 
     it 'rejects unrecognised characters', ->
@@ -163,17 +221,40 @@ spec ->
     describe ':peek', ->
       it 'matches :next', ->
         lexer = Lexer '()'
-        assert_that lexer\peek!, deep_eq { token_type: PAREN_OPEN }
-        assert_that lexer\peek!, deep_eq { token_type: PAREN_OPEN }
-        assert_that lexer\next!, deep_eq { token_type: PAREN_OPEN }
-        assert_that lexer\peek!, deep_eq { token_type: PAREN_CLOSE }
-        assert_that lexer\peek!, deep_eq { token_type: PAREN_CLOSE }
-        assert_that lexer\next!, deep_eq { token_type: PAREN_CLOSE }
+        assert_that lexer\peek!, deep_eq { type: T_PAREN_OPEN }
+        assert_that lexer\peek!, deep_eq { type: T_PAREN_OPEN }
+        assert_that lexer\next!, deep_eq { type: T_PAREN_OPEN }
+        assert_that lexer\peek!, deep_eq { type: T_PAREN_CLOSE }
+        assert_that lexer\peek!, deep_eq { type: T_PAREN_CLOSE }
+        assert_that lexer\next!, deep_eq { type: T_PAREN_CLOSE }
 
-      it 'returns nil on empty peek', ->
+      it 'returns nil at EOF', ->
         lexer = Lexer ''
         expect_that lexer\peek!, eq nil
         expect_that lexer\peek!, eq nil
+
+  describe 'Parser', ->
+    describe 'run on simple types', ->
+      it 'accepts primitives', ->
+        expect_that (type_checker 'nil'), anything!
+        expect_that (type_checker 'number'), anything!
+        expect_that (type_checker 'string'), anything!
+        expect_that (type_checker 'table'), anything!
+        expect_that (type_checker 'coroutine'), anything!
+
+      it 'accepts custom types', ->
+        expect_that (type_checker 'CustomType'), anything!
+
+      it 'rejects unknown primitives', ->
+        expect_that (-> type_checker, 'custom'), errors matches [[type 'custom' is not Lua primitive]]
+
+  describe 'declare_type', ->
+    it 'rejects false primitives', ->
+      expect_that (-> declare_type 'custom'), errors matches 'custom types must start with uppercase'
+
+    it 'rejects redefinition', ->
+      declare_type 'Custom', 'number'
+      expect_that (-> declare_type 'Custom'), errors matches [[cannot redefine type 'Custom']]
 
   -- describe 'typed', ->
   --   it 'requires two arguments', ->
@@ -187,6 +268,8 @@ spec ->
   --     expect_that (-> typed 'number', nil), errors anything!
   --     expect_that (-> typed 'number', 123), no_errors!
 
-(require 'spec').run_tests!
+import set_log_verbosity from require 'fat.logger'
+set_log_verbosity true
+(require 'spec').run_tests 'declare_type rejects redefinition'
 
--- type_checker '(string, string) -> boolean'
+-- print 'type checker:', type_checker 'boolean'

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -805,4 +805,3 @@ spec ->
 -- set_log_verbosity true
 DEBUG = true
 (require 'spec').run_tests select 1, ...
--- TODO(kcza): optional values

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -413,6 +413,8 @@ named_type = (name) ->
     error repr name
   if known_primitives[name]?
     Primitive name
+  else if name == 'any'
+    Any!
   else if not name\match '^[A-Z]'
     error "cannot use '#{name}' as user type name: name must start with an uppercase letter"
   else
@@ -426,6 +428,13 @@ class Primitive
   checker: (checker_builder=CheckerBuilder!) =>
     with checker_builder
       \add C_ASSERT_PRIMITIVE, @name
+
+class Any
+  __tostring: =>
+    'any'
+
+  checker: (checker_builder=CheckerBuilder!) =>
+    checker_builder -- No checks required.
 
 class UserType
   new: (@name) =>
@@ -879,6 +888,7 @@ spec ->
         * type ""
         * type ->
         * type coroutine.create ->
+        * 'any'
       for simple_type in *simple_types
         expect_that (tokens simple_type), deep_eq {
           Symbol T_NAME, simple_type
@@ -944,6 +954,7 @@ spec ->
         expect_that (parse 'table'), deep_eq Primitive type {}
         expect_that (parse 'function'), deep_eq Primitive type ->
         expect_that (parse 'thread'), deep_eq Primitive type coroutine.create ->
+        expect_that (parse 'any'), deep_eq Any!
 
       it 'accepts user types', ->
         expect_that (parse 'UserType'), deep_eq UserType 'UserType'
@@ -1051,6 +1062,16 @@ spec ->
       expect_that (-> T 'nil', 123), errors matches 'incorrect type: expected nil but got number'
       expect_that (-> T 'number', nil), errors matches 'incorrect type: expected number but got nil'
       expect_that (-> T 'string', 123), errors matches 'incorrect type: expected string but got number'
+
+    it 'checks any', ->
+      values =
+        * 123
+        * 'str'
+        * {}
+        * ->
+        * coroutine.create ->
+      for value in *values
+        expect_that (-> T 'any', value), no_errors!
 
     it 'checks string types', ->
       expect_that (-> T '"hello"', 'hello'), no_errors!

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -519,6 +519,11 @@ validate = (check_prog) ->
 
 value_stack_size = 0
 value_stack = {}
+check_error = (...) ->
+  for i = 1, value_stack_size
+    value_stack[i] = nil
+  value_stack_size = 0
+  error ...
 check = (check_prog, value) ->
   value_stack_size = 1
   value_stack[1] = value
@@ -545,12 +550,12 @@ check = (check_prog, value) ->
           ty = type value_stack[value_stack_size]
           pc += 1
           if ty != [pc]
-            error "incorrect type: expected #{check_prog[pc]} but got #{ty}"
+            check_error "incorrect type: expected #{check_prog[pc]} but got #{ty}"
         when C_ASSERT_LEN
           len = #value_stack[value_stack_size-1]
           first_nil_index = value_stack[value_stack_size]
           if len != first_nil_index-1
-            error "incorrect type: expected array but got table"
+            check_error "incorrect type: expected array but got table"
         when C_GET_FIELD
           value_stack_size += 1
           value_stack[value_stack_size] = value_stack[value_stack_size-2][value_stack[value_stack_size-1]]
@@ -571,9 +576,12 @@ check = (check_prog, value) ->
           else
             pc = [pc + 1] - 1
         else
-          error "internal error: illegal type-checker VM instruction #{[pc]}@#{pc}"
+          check_error "internal error: illegal type-checker VM instruction #{[pc]}@#{pc}"
   if true -- DEBUG
     print "FINAL stack state #{check_prog[pc]}@#{pc} [#{value_stack_size}]:\n\t#{table.concat [ "#{i}:\t#{repr value_stack[i]}" for i = 1, value_stack_size], '\n\t'}"
+  assert value_stack_size == 1, "internal error: value stack is not 1"
+  value_stack[1] = nil
+  value_stack_size = 0
 
 export declare_type = (name, type_spec) ->
   if not (name\sub 1, 1)\match '^[A-Z_]$'

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -1303,6 +1303,9 @@ spec ->
 
       expect_that (-> (F '() -> <number, string...>', -> 123, 'hello', true)!), errors matches 'incorrect type: expected string but got boolean'
 
+    it 'prevents execution on invalid args', ->
+      expect_that (-> (F '(string) -> nil', -> error 'OH NO') 123), errors matches 'incorrect type: expected string but got number'
+
     it 'rejects non-function types', ->
       expect_that (-> F '{}', ->), errors matches 'cannot typecheck: expected a function type'
 

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -414,6 +414,7 @@ class Array
 
       loop_exit_target\resolve_here!
       \add C_POP
+      \add C_DECR
       \add C_ASSERT_LEN
       \add C_POP
 
@@ -619,6 +620,7 @@ C_ASSERT_TRUTHY = <tostring>: => '<assert-truthy>'
 C_ASSERT_LEN = <tostring>: => '<assert-len>'
 C_GET_FIELD = <tostring>: => '<field>'
 C_INCR = <tostring>: => '<incr>'
+C_DECR = <tostring>: => '<decr>'
 C_NEXT = <tostring>: => '<next>'
 C_JMP = <tostring>: => '<jmp>'
 C_JMP_IF_NIL = <tostring>: => '<jnil>'
@@ -694,15 +696,17 @@ check = (check_prog, value, root=true) ->
           if not stack[stack_size]
             check_error "incorrect type: expected a truthy value but got #{stack[stack_size]}"
         when C_ASSERT_LEN
-          len = #stack[stack_size-1]
-          first_nil_index = stack[stack_size]
-          if len != first_nil_index-1
+          actual_len = #stack[stack_size-1]
+          counted_len = stack[stack_size]
+          if counted_len != actual_len
             check_error "incorrect type: expected array but got table"
         when C_GET_FIELD
           stack_size += 1
           stack[stack_size] = stack[stack_size-2][stack[stack_size-1]]
         when C_INCR
           stack[stack_size] += 1
+        when C_DECR
+          stack[stack_size] -= 1
         when C_NEXT
           tab = stack[stack_size-1]
           idx = stack[stack_size]

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -281,52 +281,33 @@ class TypeSpecParser extends Parser
     table
 
   parse_table_content: =>
-    first_elem = @select
-      * token: T_NAME
-        action: -> @expect T_NAME
-      * token: T_BRACE_CLOSE
-        action: -> nil
-      otherwise: @\parse_type
-    if first_elem == nil
+    if (@lexer\peek! ?? {}).type == T_BRACE_CLOSE
       return Struct {}
 
-    second_elem = @select
+    checkpoint = @lexer\checkpoint!
+    first_elem_is_field_name = (@maybe T_NAME)? and (@maybe T_COLON)?
+    @lexer\restore checkpoint
+
+    if first_elem_is_field_name
+      return Struct @parse_repeat_separated @\parse_field, T_COMMA
+
+    first_type = @parse_type!
+    table_content_type = @select
       * token: T_BRACE_CLOSE
         action: -> 'set'
       * token: T_ARROW
         action: -> 'mapping'
-      * token: T_COLON
-        action: -> 'struct'
 
-    switch second_elem
+    switch table_content_type
       when 'set'
-        if 'string' == type first_elem
-          first_elem = named_type first_elem
-        Set first_elem
+        Set first_type
       when 'mapping'
-        if 'string' == type first_elem
-          first_elem = named_type first_elem
         { _, maps_to } = @sequence
           * token: T_ARROW
           * action: @\parse_type
-        Mapping first_elem, maps_to
-      when 'struct'
-        @expect T_COLON
-        first_type = @parse_type!
-        first_field = Field first_elem, first_type
-        if @lexer\peek!.type == T_COMMA
-          @expect T_COMMA
-        remainder = @select
-          * token: T_BRACE_CLOSE
-            action: -> nil
-          * token: T_NAME
-            action: -> @parse_repeat_separated @\parse_field, T_COMMA
-        if remainder?
-          Struct { first_field, ...remainder}
-        else
-          Struct { first_field }
+        Mapping first_type, maps_to
       else
-        error "internal error: unexpected symbol: #{repr second_elem}"
+        error "internal error: illegal table contents type: #{repr table_content_type}"
 
   parse_field: =>
     {name, _, type} = @sequence
@@ -431,15 +412,15 @@ class Lexer
         @done = true
       ret
 
-  snapshot: =>
-    Snapshot @index, @peeked
+  checkpoint: =>
+    Checkpoint @index, @peeked
 
-  restore: (snapshot) =>
-    { :index, :peeked } = snapshot
+  restore: (checkpoint) =>
+    { :index, :peeked } = checkpoint
     @index = index
     @peeked = peeked
 
-class Snapshot
+class Checkpoint
   new: (@index, @peeked) =>
 
 class Symbol
@@ -1197,6 +1178,9 @@ spec ->
           * Mapping (Primitive 'number'), Primitive 'string'
           * Primitive 'table'
           * Primitive 'function'
+        expect_that (parse '{string|number}'), deep_eq Set Disjunction
+          * Primitive 'string'
+          * Primitive 'number'
 
       it 'gives precedence to conjunctions', ->
         expect_that (parse 'string+number|boolean'), deep_eq Disjunction
@@ -1321,6 +1305,21 @@ spec ->
       expect_that (-> T 'string|number', 'hello'), no_errors!
       expect_that (-> T 'string|number', 123), no_errors!
       expect_that (-> T 'string|number', true), errors matches 'incorrect type: expected string|number but got boolean'
+
+    it 'checks nested inline disjunctions', ->
+      expect_that (-> T 'number|{string|number}|string', 'hello'), no_errors!
+      expect_that (-> T 'number|{string|number}|string', {hello: true}), no_errors!
+      expect_that (-> T 'number|{string|number}|string', {[1]: true}), no_errors!
+      expect_that (-> T 'number|{string|number}|string', ->), errors matches 'incorrect type: expected number|{string|number}|string but got function'
+
+    it 'checks nested recursive disjunctions', ->
+      declare_type 'InnerDisjunction', 'string|number'
+      expect_that (-> T 'boolean|InnerDisjunction|function', true), no_errors!
+      expect_that (-> T 'boolean|InnerDisjunction|function', 'hello'), no_errors!
+      expect_that (-> T 'boolean|InnerDisjunction|function', 123), no_errors!
+      expect_that (-> T 'boolean|InnerDisjunction|function', ->), no_errors!
+
+      expect_that (-> T 'boolean|InnerDisjunction|function', {}), errors matches 'incorrect type: expected boolean|InnerDisjunction|function but got table'
 
   describe 'declare_type', ->
     it 'requires two arguments', ->

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -1,5 +1,5 @@
 local *
-local Parser
+local Parser, Remainder
 
 import spec, repr from require 'spec'
 
@@ -34,20 +34,29 @@ export F = (type_spec, fn) ->
   fn_type = function_type type_spec
 
   return_types = fn_type\return_checkers!
+  n_return_types = #return_types
   check_returns = (...) ->
-    n_return_values = select '#', ...
-    if #return_types < n_return_values
-      error 'function returned too many values'
-    for i = 1, #return_types
+    for i = 1, n_return_types
       check return_types[i], select i, ...
+    for i = n_return_types+1, select '#', ...
+      checker = return_types[i]
+      if not checker?
+        error 'function returned too many values'
+      check checker, select i, ...
+
     ...
 
   param_types = fn_type\param_checkers!
+  n_param_types = #param_types
   (...) ->
-    if #param_types < select '#', ...
-      error 'function passed too many arguments'
-    for i = 1, #param_types
+    for i = 1, n_param_types
       check param_types[i], select i, ...
+    for i = n_param_types+1, select '#', ...
+      checker = param_types[i]
+      if not checker?
+        error 'function given too many arguments'
+      check checker, select i, ...
+
     check_returns fn ...
 
 function_types = {}
@@ -198,10 +207,23 @@ class TypeSpecParser extends Parser
       types = {}
     else
       {types, _} = @sequence
-        * action: -> @parse_repeat_separated @\parse_type, T_COMMA
+        * action: ->
+          @parse_repeat_separated @\parse_function_io_type, T_COMMA
         * token: T_PAREN_CLOSE
     if not @maybe T_ARROW
+      for ty in *types
+        if ty\is Remainder
+          error 'tuple type cannot contain varargs'
       return Tuple types
+
+    for ty in *types[,-1]
+      if ty\is Remainder
+        error 'varargs can only be declared at end of a param type list'
+
+    last_ty = types[#types]
+    if last_ty? and last_ty\is Remainder
+      types.<> = __index: => last_ty.type
+      types[#types] = nil
 
     Function types, @parse_return_type!
 
@@ -209,8 +231,10 @@ class TypeSpecParser extends Parser
     @select
       * token: T_NAME
         action: ->
-          ty = @parse_named_type!
-          if ty.name == 'nil'
+          ty = @parse_function_io_type!
+          if ty\is Remainder
+            <index>: => ty.type
+          else if ty.name == 'nil'
             {} -- 'nil' is an alternative spelling of '<>'
           else
             { ty }
@@ -219,11 +243,28 @@ class TypeSpecParser extends Parser
           @expect T_ANGLE_OPEN
           if @maybe  T_ANGLE_CLOSE
             return {}
-          types = @parse_repeat_separated @\parse_type, T_COMMA
+          types = @parse_repeat_separated @\parse_function_io_type, T_COMMA
           @expect T_ANGLE_CLOSE
+
+          for ty in *types[,-1]
+            if ty\is Remainder
+              error 'variable returns can only be declared at end of a return type list'
+
+          last_ty = types[#types]
+          if last_ty? and last_ty\is Remainder
+            types.<> = __index: => last_ty.type
+            types[#types] = nil
+
           types
       otherwise: ->
-        { @parse_type! }
+        { @parse_function_io_type! }
+
+  parse_function_io_type: =>
+    ty = @parse_type!
+    if (@maybe T_DOTDOTDOT)?
+      Remainder ty
+    else
+      ty
 
   parse_table: =>
     {_, table, _} = @sequence
@@ -299,6 +340,7 @@ T_ANGLE_CLOSE = <tostring>: => '">"'
 T_COMMA = <tostring>: => "','"
 T_COLON = <tostring>: => "':'"
 T_ARROW = <tostring>: => "'->'"
+T_DOTDOTDOT = <tostring>: => "'...'"
 T_QUESTION = <tostring>: => "'?'"
 T_PLUS = <tostring>: => "'+'"
 T_PIPE = <tostring>: => "'|'"
@@ -332,6 +374,8 @@ class Lexer
           T_COLON, nil, #match
         else if match = type_spec\match '^->', @index
           T_ARROW, nil, #match
+        else if match = type_spec\match '^%.%.%.', @index
+          T_DOTDOTDOT, nil, #match
         else if match = type_spec\match '^<', @index
           T_ANGLE_OPEN, nil, #match
         else if match = type_spec\match '^>', @index
@@ -598,53 +642,86 @@ class Mapping using Is
 
 class Function using Is
   new: (@param_types, @return_types) =>
+    @remainder_param_type = param_types.<>?.__index?!
+    @remainder_return_type = return_types.<>?.__index?!
     @_param_checkers = nil
     @_return_checkers = nil
 
   param_checkers: =>
     if param_checkers = @_param_checkers
       return param_checkers
-    param_checkers = with {}
+    param_checkers = with <>: {}
       for param_type in *@param_types
         [] = param_type\checker!\build!
+      if @param_types.<>?
+        if remainder_type = @remainder_param_type
+          remainder_type_checker = remainder_type\checker!\build!
+          .<index> = => remainder_type_checker
     @_param_checkers = param_checkers
     param_checkers
 
   return_checkers: =>
     if return_checkers = @_return_checkers
       return return_checkers
-    return_checkers = with {}
+    return_checkers = with <>: {}
       for return_type in *@return_types
         [] = return_type\checker!\build!
+      if @return_types.<>?
+        if remainder_type = @remainder_return_type
+          remainder_type_checker = remainder_type\checker!\build!
+          .<index> = => remainder_type_checker
     @_return_checkers = return_checkers
     return_checkers
 
   __tostring: =>
     table.concat with {}
       [] = '('
-      first = true
+      first_param = true
       for param_type in *@param_types
-        if not first
+        if not first_param
           [] = ", "
-        first = false
+        first_param = false
 
         [] = tostring param_type
+      if @remainder_param_type?
+        if not first_param
+          [] = ', '
+        [] = tostring @remainder_param_type
+        [] = '...'
       [] = ') -> '
       if #@return_types == 1
-        [] = tostring @return_types[1]
+        if @remainder_return_type?
+          [] = tostring remainder_return_type
+          [] = '...'
+        else
+          [] = tostring @return_types[1]
       else
         [] = '<'
-        first = true
+        first_ret = true
         for return_type in *@return_types
-          if not first
+          if not first_ret
             [] = ", "
-          first = false
+          first_ret = false
           [] = tostring return_type
+        if @remainder_return_type?
+          if not first_ret
+            [] = ', '
+          [] = tostring @remainder_return_type
+          [] = '...'
         [] = '>'
 
   checker: (checker_builder=CheckerBuilder!) =>
     with checker_builder
       \add C_ASSERT_PRIMITIVE, 'function'
+
+class Remainder using Is
+  new: (@type) =>
+
+  __tostring: =>
+    "#{@type}..."
+
+  checker: (checker_builder=CheckerBuilder!) =>
+    error 'internal error: Remainder unresolved in AST'
 
 class Disjunction using Is
   new: (@types) =>
@@ -905,7 +982,7 @@ spec ->
       }
 
     it 'emits strucural tokens', ->
-      expect_that (tokens '(),{}[]:->?+|'), deep_eq {
+      expect_that (tokens '(),{}[]:->...?+|'), deep_eq {
         Symbol T_PAREN_OPEN
         Symbol T_PAREN_CLOSE
         Symbol T_COMMA
@@ -915,6 +992,7 @@ spec ->
         Symbol T_BRACKET_CLOSE
         Symbol T_COLON
         Symbol T_ARROW
+        Symbol T_DOTDOTDOT
         Symbol T_QUESTION
         Symbol T_PLUS
         Symbol T_PIPE
@@ -1023,6 +1101,10 @@ spec ->
         expect_that (parse '(string) -> (number) -> boolean'), deep_eq Function {Primitive 'string'}, {Function {Primitive 'number'}, {Primitive 'boolean'}}
         expect_that (parse '() -> <string>'), deep_eq Function {}, {(Primitive 'string')}
         expect_that (parse '() -> <string, boolean>'), deep_eq Function {}, {(Primitive 'string'), (Primitive 'boolean')}
+
+        expect_that (parse '(string...) -> number...'), deep_eq Function {<index>: => Primitive 'string'}, {<index>: => Primitive 'number'}
+        expect_that (parse '(string...) -> <number...>'), deep_eq Function {<index>: => Primitive 'string'}, {<index>: => Primitive 'number'}
+        expect_that (parse '(boolean, string...) -> <thread, number...>'), deep_eq Function {(Primitive 'boolean'), <index>: => Primitive 'string'}, {(Primitive 'thread'), <index>: => Primitive 'number'}
 
       it 'accepts conjunctions', ->
         expect_that (parse '[string]+{number->string}+table+function'), deep_eq Conjunction
@@ -1201,11 +1283,25 @@ spec ->
     it 'accepts absent optional arguments', ->
       expect_that (-> (F '() -> ?string', ->)!), no_errors!
 
-    it 'accepts absent optional retunsr', ->
+    it 'accepts remainder arguments', ->
+      expect_that (-> (F '(string...) -> nil', ->)!), no_errors!
+      expect_that (-> (F '(string...) -> nil', ->) 'hello', 'world'), no_errors!
+      expect_that (-> (F '(number, string...) -> nil', ->) 123, 'hello', 'world'), no_errors!
+
+      expect_that (-> (F '(number, string...) -> nil', (...) ->) 123, 'hello', true), errors matches 'incorrect type: expected string but got boolean'
+
+    it 'accepts absent optional returns', ->
       expect_that (-> (F '() -> nil', ->)!), no_errors!
 
     it 'accepts multiple return values', ->
       expect_that (-> (F '() -> <string, boolean>', -> 'a', true)!), no_errors!
+
+    it 'accepts remainder return values', ->
+      expect_that (-> (F '() -> string...', ->)!), no_errors!
+      expect_that (-> (F '() -> string...', ->, 'hello', 'world')!), no_errors!
+      expect_that (-> (F '() -> <number, string...>', -> 123, 'hello', 'world')!), no_errors!
+
+      expect_that (-> (F '() -> <number, string...>', -> 123, 'hello', true)!), errors matches 'incorrect type: expected string but got boolean'
 
     it 'rejects non-function types', ->
       expect_that (-> F '{}', ->), errors matches 'cannot typecheck: expected a function type'
@@ -1214,7 +1310,7 @@ spec ->
       expect_that (-> (F '(string) -> table', ->) 123), errors matches 'incorrect type: expected string but got number'
 
     it 'rejects extra arguments', ->
-      expect_that (-> (F '(string) -> table', ->) 'a', 'b'), errors matches 'function passed too many arguments'
+      expect_that (-> (F '(string) -> table', ->) 'a', 'b'), errors matches 'function given too many arguments'
 
     it 'rejects incorrect-type return values', ->
       expect_that (-> (F '(table) -> string', ->) {}), errors matches 'incorrect type: expected string but got nil'

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -1,5 +1,4 @@
 local *
-local Parser, Remainder
 
 import spec, repr from require 'spec'
 

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -722,9 +722,31 @@ class Remainder using Is
 
 class Disjunction using Is
   new: (@types) =>
+    if #@types <= 1
+      error 'internal error: disjunction has too few elements'
 
   __tostring: =>
     table.concat [tostring ty for ty in *@types], '|'
+
+  checker: (checker_builder=CheckerBuilder!) =>
+    with checker_builder
+      \add C_PUSH_UNION_CTX, @
+      next_variant_jump = \add_with_unresolved_target C_SET_UNION_BAIL_TARGET
+      @types[1]\checker checker_builder
+
+      ok_jumps = {}
+      for ty in *@types[2,]
+        ok_jumps[] = \add_with_unresolved_target C_JMP
+
+        next_variant_jump\resolve_here!
+        \add C_CLEAR_BAILING
+        next_variant_jump = \add_with_unresolved_target C_SET_UNION_BAIL_TARGET
+        ty\checker checker_builder
+
+      next_variant_jump\resolve_here!
+      for ok_jump in *ok_jumps
+        ok_jump\resolve_here!
+      \add C_POP_UNION_CTX
 
 class Conjunction using Is
   new: (@types) =>
@@ -802,6 +824,10 @@ C_NEXT = <tostring>: => '<next>'
 C_JMP = <tostring>: => '<jmp>'
 C_JMP_IF_NIL = <tostring>: => '<jnil>'
 C_PUSH_CHECKER = <tostring>: => '<push-checker>'
+C_PUSH_UNION_CTX = <tostring>: => '<push-union-ctx>'
+C_CLEAR_BAILING = <tostring>: => '<clear-bailing>'
+C_SET_UNION_BAIL_TARGET = <tostring>: => '<set-union-bail-target>'
+C_POP_UNION_CTX = <tostring>: => '<pop-union-ctx>'
 V_NIL = <tostring>: => 'nil'
 
 checker_program_repr = (checker) ->
@@ -811,14 +837,11 @@ LABEL_PLACEHOLDER = <tostring>: => '<LABEL-PLACEHOLDER>'
 
 stack_size = 0
 stack = {}
+num_unions = 0
+union_depths = {}
+union_bail_jumps = {}
+root_union = nil
 num_running_checkers = 0
-check_error = (...) ->
-  for i = 1, stack_size
-    stack[i] = nil
-  stack_size = 0
-  num_running_checkers = 0
-  error ...
-
 instruction_counts = {}
 
 export MAX_CHECKER_DEPTH = 1000
@@ -827,11 +850,9 @@ check = (check_prog, value, root=true) ->
     -- Prime stack.
     stack_size = 1
     stack[1] = value
-    num_running_checkers = 0
+    num_running_checkers = 1
   initial_stack_size = stack_size
-
   initial_num_running_checkers = num_running_checkers
-  num_running_checkers += 1
 
   if num_running_checkers >= MAX_CHECKER_DEPTH
     error "type checker recursed too many times (#{num_running_checkers} times). If this is okay, increase the MAX_CHECKER_DEPTH"
@@ -839,7 +860,25 @@ check = (check_prog, value, root=true) ->
   if DEBUG
     print "running checker:\n\t#{checker_program_repr check_prog}"
   with check_prog
-    local pc = -1
+    local pc
+    bailing = false
+    check_error = (msg) ->
+      -- TODO(kcza): make this a macro!
+      if num_unions == 0 and 'function' == type msg
+        msg = msg! -- Resolve before touching stack.
+
+      new_size = union_depths[num_unions] ?? 0
+      for i = new_size + 1, stack_size
+        stack[i] = nil
+      stack_size = new_size
+
+      if num_unions == 0
+        error msg
+      print "BAILING to #{union_bail_jumps[num_unions]}"
+      pc = union_bail_jumps[num_unions] - 2
+      bailing = true
+
+    pc = -1
     while true
       pc += 2
       instruction = [pc]
@@ -869,10 +908,13 @@ check = (check_prog, value, root=true) ->
           ty = type stack[stack_size]
           arg = [pc + 1]
           if ty != arg
-            check_error "incorrect type: expected #{arg} but got #{ty}"
+            print 'OH NO'
+            print num_unions
+            check_error -> "incorrect type: expected #{arg} but got #{ty}"
+            print 'OH YEAH'
         when C_ASSERT_TRUTHY
           if not stack[stack_size]
-            check_error "incorrect type: expected a truthy value but got #{stack[stack_size]}"
+            check_error -> "incorrect type: expected a truthy value but got #{stack[stack_size]}"
         when C_ASSERT_LEN
           actual_len = #stack[stack_size-1]
           counted_len = stack[stack_size]
@@ -880,7 +922,7 @@ check = (check_prog, value, root=true) ->
             check_error "incorrect type: expected array but got table"
         when C_ASSERT_EQ
           if stack[stack_size] != [pc + 1]
-            check_error "incorrect type: expected #{type [pc + 1]} #{repr [pc + 1]}"
+            check_error -> "incorrect type: expected #{type [pc + 1]} #{repr [pc + 1]}"
         when C_GET_FIELD
           stack_size += 1
           stack[stack_size] = stack[stack_size-2][stack[stack_size-1]]
@@ -905,13 +947,50 @@ check = (check_prog, value, root=true) ->
           checker = type_checkers[arg]
           if not checker?
             error "cannot typecheck #{arg}: type not defined"
-          check checker, nil, false
+
+          num_running_checkers += 1
+          recovered_err = nil
+          try -- TODO(kcza): remove this try
+            recovered_err = check checker, nil, false
+          catch err
+            recovered_err = err
+            print 'RECOVERED'
+          num_running_checkers -= 1
+
+          if recovered_err?
+            if num_unions == 0
+              error recovered_err
+            pc = union_bail_jumps[num_unions] - 2
+        when C_CLEAR_BAILING
+          bailing = false
+        when C_SET_UNION_BAIL_TARGET
+          -- TODO(kcza): CHECK VIA USER TYPES!
+          union_bail_jumps[num_unions] = [pc + 1]
+        when C_PUSH_UNION_CTX
+          num_unions += 1
+          union_depths[num_unions] = #stack
+          if num_unions == 1
+            root_union = [pc + 1]
+            print "set root union to #{[pc + 1]}; #{[pc]}"
+          print "ROOT UNION IS #{root_union}"
+        when C_POP_UNION_CTX
+          union_bail_jumps[num_unions] = nil
+          union_depths[num_unions] = nil
+          num_unions -= 1
+
+          if bailing
+            if num_unions == 0
+              check_error "incorrect type: expected #{root_union} but got #{type stack[stack_size]}"
+            else
+              check_error! -- Unwind.
+
+          if num_unions == 0
+            root_union = nil
         else
-          check_error "internal error: illegal type-checker VM instruction #{[pc]}@#{pc}"
+          error "internal error: illegal type-checker VM instruction #{[pc]}@#{pc}"
     if DEBUG
       print "FINAL stack state #{check_prog[pc-2]}@#{pc-2} [#{stack_size}]:\n\t#{table.concat [ "#{i}:\t#{repr stack[i]}" for i = 1, stack_size], '\n\t'}"
 
-    num_running_checkers -= 1
     assert num_running_checkers == initial_num_running_checkers, "internal error: checker depth incorrectly handled: expected #{initial_num_running_checkers} but got #{num_running_checkers}"
     assert stack_size == initial_stack_size, "internal error: value stack incorrectly handled"
     if root
@@ -1236,6 +1315,11 @@ spec ->
 
       expect_that (-> T 'string+number', 123), errors matches 'incorrect type: expected string but got number'
       expect_that (-> T 'string+number', 'hello'), errors matches 'incorrect type: expected number but got string'
+
+    it 'checks disjunctions', ->
+      expect_that (-> T 'string|number', 'hello'), no_errors!
+      expect_that (-> T 'string|number', 123), no_errors!
+      expect_that (-> T 'string|number', true), errors matches 'incorrect type: expected string|number but got boolean'
 
   describe 'declare_type', ->
     it 'requires two arguments', ->

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -470,40 +470,44 @@ check = (check_prog, value) ->
   value_stack_size = 1
   value_stack[1] = value
 
-  for pc = 1, #check_prog
-    switch check_prog[pc]
-      when C_PUSH
-        pc += 1
-        value = check_prog[pc]
-        value_stack_size += 1
-        value_stack[value_stack_size] = value
-      when C_POP
-        value_stack[value_stack_size] = nil
-        value_stack_size -= 1
-      when C_ASSERT_PRIMITIVE
-        ty = type value_stack[value_stack_size]
-        pc += 1
-        if ty != check_prog[pc]
-          error "incorrect type: expected #{check_prog[pc]} but got #{ty}"
-      when C_GET_FIELD
-        value_stack_size += 1
-        value_stack[value_stack_size] = value_stack[value_stack_size-2][value_stack[value_stack_size-1]]
-      when C_INCR
-        value_stack[value_stack_size] += 1
-      when C_JMP
-        pc = chec_prog[pc + 1] - 1
-      when C_JMP_IF_NIL
-        if value_stack[value_stack_size]?
-          pc = chec_prog[pc] - 1
-        else
+  with check_prog
+    local pc = 0
+    n_instructions = #check_prog
+    while pc <= n_instructions
+      pc += 1
+      switch [pc]
+        when C_PUSH
           pc += 1
+          value = [pc]
+          value_stack_size += 1
+          value_stack[value_stack_size] = value
+        when C_POP
+          value_stack[value_stack_size] = nil
+          value_stack_size -= 1
+        when C_ASSERT_PRIMITIVE
+          ty = type value_stack[value_stack_size]
+          pc += 1
+          if ty != [pc]
+            error "incorrect type: expected #{check_prog[pc]} but got #{ty}"
+        when C_GET_FIELD
+          value_stack_size += 1
+          value_stack[value_stack_size] = value_stack[value_stack_size-2][value_stack[value_stack_size-1]]
+        when C_INCR
+          value_stack[value_stack_size] += 1
+        when C_JMP
+          pc = chec_prog[pc + 1] - 1
+        when C_JMP_IF_NIL
+          if value_stack[value_stack_size]?
+            pc = chec_prog[pc] - 1
+          else
+            pc = [pc + 1] - 1
 
 export declare_type = (name, type_spec) ->
   if not (name\sub 1, 1)\match '^[A-Z_]$'
     error "cannot declare type '#{name}': custom types must start with uppercase or '_'"
   if type_checkers[name]?
     error "cannot redefine type '#{name}'"
-  type_checkers[name] = type_checker name
+  type_checkers[name] = type_checker type_spec
 
 export deactivate = ->
   T = (_, fn) -> fn

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -371,9 +371,10 @@ class List
       [] = C_JMP
       [] = loop_start
 
-      [] = C_POP -- TODO(kcza): check stack on early exit
       [loop_exit_jump_index] = #prog + 1
-
+      [] = C_POP
+      [] = C_ASSERT_LEN
+      [] = C_POP -- TODO(kcza): check stack on early exit
 
 class Tuple
   new: (@elem_types) =>
@@ -475,6 +476,7 @@ class Function
 C_PUSH = <tostring>: => '<push>'
 C_POP = <tostring>: => '<pop>'
 C_ASSERT_PRIMITIVE = <tostring>: => '<assert-primitive>'
+C_ASSERT_LEN = <tostring>: => '<assert-len>'
 C_GET_FIELD = <tostring>: => '<field>'
 C_INCR = <tostring>: => '<incr>'
 C_JMP = <tostring>: => '<jmp>'
@@ -512,6 +514,11 @@ check = (check_prog, value) ->
           pc += 1
           if ty != [pc]
             error "incorrect type: expected #{check_prog[pc]} but got #{ty}"
+        when C_ASSERT_LEN
+          len = #value_stack[value_stack_size-1]
+          first_nil_index = value_stack[value_stack_size]
+          if len != first_nil_index-1
+            error "incorrect type: expected List but got table"
         when C_GET_FIELD
           value_stack_size += 1
           value_stack[value_stack_size] = value_stack[value_stack_size-2][value_stack[value_stack_size-1]]
@@ -698,7 +705,7 @@ spec ->
       expect_that (-> T '[[number]]', {{123}, {312}}), no_errors!
 
       expect_that (-> T '[string]', 123), errors matches 'incorrect type: expected table but got number'
-      expect_that (-> T '[string]', {field: 456}), errors matches 'incorrect type: expected string but got number'
+      expect_that (-> T '[[number]]', {{123}, {'asdf'}}), errors matches 'incorrect type: expected number but got string'
 
       hybrid = {123, 456, 789, field: 'a'}
       if #hybrid != 3

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -3,7 +3,7 @@ local Parser
 
 import spec, repr from require 'spec'
 
-export t = (type_spec, value) ->
+export T = (type_spec, value) ->
   if not type_spec?
     error 'cannot typecheck: no type spec provided'
 
@@ -506,7 +506,7 @@ export declare_type = (name, type_spec) ->
   type_checkers[name] = type_checker name
 
 export deactivate = ->
-  t = (_, fn) -> fn
+  T = (_, fn) -> fn
 
 spec ->
   import assert_that, expect_that, describe, it, matchers from require 'spec'
@@ -638,49 +638,55 @@ spec ->
     --   declare_type 'Custom', 'number'
     --   expect_that (-> declare_type 'Custom'), errors matches [[cannot redefine type 'Custom']]
 
-  describe 't', ->
+  describe 'T', ->
     it 'requires two arguments', ->
-      expect_that (-> t!), errors matches 'cannot typecheck: no type spec provided'
+      expect_that (-> T!), errors matches 'cannot typecheck: no type spec provided'
 
-    it 'checks primitive types', ->
-      expect_that (-> t 'nil', nil), no_errors!
-      expect_that (-> t 'number', 123), no_errors!
-      expect_that (-> t 'string', 'some-string'), no_errors!
+    it 'checks primitives', ->
+      expect_that (-> T 'nil', nil), no_errors!
+      expect_that (-> T 'number', 123), no_errors!
+      expect_that (-> T 'string', 'some-string'), no_errors!
 
-      expect_that (-> t 'nil', 123), errors matches 'incorrect type: expected nil but got number'
-      expect_that (-> t 'number', nil), errors matches 'incorrect type: expected number but got nil'
-      expect_that (-> t 'string', 123), errors matches 'incorrect type: expected string but got number'
+      expect_that (-> T 'nil', 123), errors matches 'incorrect type: expected nil but got number'
+      expect_that (-> T 'number', nil), errors matches 'incorrect type: expected number but got nil'
+      expect_that (-> T 'string', 123), errors matches 'incorrect type: expected string but got number'
+
+    it 'checks optionals', ->
+      expect_that (-> T '?number', nil), no_errors!
+      expect_that (-> T '?number', 123), no_errors!
+      expect_that (-> T '?number', 'str'), errors matches 'incorrect type: expected number but got string'
+      expect_that (-> T '?(number)', 'str'), errors matches 'incorrect type: expected table but got string'
 
     it 'checks tuples', ->
-      expect_that (-> t '()', {}), no_errors!
-      expect_that (-> t '(number, boolean, string)', {123, true, 'hello'}), no_errors!
-      expect_that (-> t '(number, boolean, string)', {123, true, 'hello', coroutine.create ->}), no_errors!
-      expect_that (-> t '((number, boolean), (string, thread))', {{123, true}, {'hello', coroutine.create ->}}), no_errors!
+      expect_that (-> T '()', {}), no_errors!
+      expect_that (-> T '(number, boolean, string)', {123, true, 'hello'}), no_errors!
+      expect_that (-> T '(number, boolean, string)', {123, true, 'hello', coroutine.create ->}), no_errors!
+      expect_that (-> T '((number, boolean), (string, thread))', {{123, true}, {'hello', coroutine.create ->}}), no_errors!
 
-      expect_that (-> t '(number, boolean, string)', nil), errors matches 'incorrect type: expected table but got nil'
-      expect_that (-> t '(number, boolean, string)', {}), errors matches 'incorrect type: expected number but got nil'
-      expect_that (-> t '(number, boolean, string)', {123}), errors matches 'incorrect type: expected boolean but got nil'
-      expect_that (-> t '(number, boolean, string)', {'interloper'}), errors matches 'incorrect type: expected number but got string'
+      expect_that (-> T '(number, boolean, string)', nil), errors matches 'incorrect type: expected table but got nil'
+      expect_that (-> T '(number, boolean, string)', {}), errors matches 'incorrect type: expected number but got nil'
+      expect_that (-> T '(number, boolean, string)', {123}), errors matches 'incorrect type: expected boolean but got nil'
+      expect_that (-> T '(number, boolean, string)', {'interloper'}), errors matches 'incorrect type: expected number but got string'
 
     it 'checks structs', ->
-      expect_that (-> t '{}', {}), no_errors!
-      expect_that (-> t '{}', {123}), no_errors!
-      expect_that (-> t '{}', {hello: 123}), no_errors!
-      expect_that (-> t '{hello: string}', {hello: 'hello'}), no_errors!
-      expect_that (-> t '{hello: {world: string}}', {hello: world: 'world'}), no_errors!
-      expect_that (-> t '{hello: {world: string}, foo: boolean}', hello: {world:'asdf'}, foo: true), no_errors!
+      expect_that (-> T '{}', {}), no_errors!
+      expect_that (-> T '{}', {123}), no_errors!
+      expect_that (-> T '{}', {hello: 123}), no_errors!
+      expect_that (-> T '{hello: string}', {hello: 'hello'}), no_errors!
+      expect_that (-> T '{hello: {world: string}}', {hello: world: 'world'}), no_errors!
+      expect_that (-> T '{hello: {world: string}, foo: boolean}', hello: {world:'asdf'}, foo: true), no_errors!
 
-      expect_that (-> t '{}', 132), errors matches 'incorrect type: expected table but got number'
-      expect_that (-> t '{hello: string}', {}), errors matches 'incorrect type: expected string but got nil'
-      expect_that (-> t '{hello: string}', hello: 123), errors matches 'incorrect type: expected string but got number'
-      expect_that (-> t '{hello: {world: string}}', hello: 123), errors matches 'incorrect type: expected table but got number'
-      expect_that (-> t '{hello: {world: string}}', hello: {}), errors matches 'incorrect type: expected string but got nil'
-      expect_that (-> t '{hello: {world: string}}', hello: world: 123), errors matches 'incorrect type: expected string but got number'
-      expect_that (-> t '{hello: {world: string}, foo: boolean}', hello: {world:'asdf'}, foo: 123), errors matches 'incorrect type: expected boolean but got number'
+      expect_that (-> T '{}', 132), errors matches 'incorrect type: expected table but got number'
+      expect_that (-> T '{hello: string}', {}), errors matches 'incorrect type: expected string but got nil'
+      expect_that (-> T '{hello: string}', hello: 123), errors matches 'incorrect type: expected string but got number'
+      expect_that (-> T '{hello: {world: string}}', hello: 123), errors matches 'incorrect type: expected table but got number'
+      expect_that (-> T '{hello: {world: string}}', hello: {}), errors matches 'incorrect type: expected string but got nil'
+      expect_that (-> T '{hello: {world: string}}', hello: world: 123), errors matches 'incorrect type: expected string but got number'
+      expect_that (-> T '{hello: {world: string}, foo: boolean}', hello: {world:'asdf'}, foo: 123), errors matches 'incorrect type: expected boolean but got number'
 
     it 'checks functions', ->
-      expect_that (-> t '() -> nil', ->), no_errors!
-      expect_that (-> t '() -> nil', {}), errors matches 'incorrect type: expected function but got table'
+      expect_that (-> T '() -> nil', ->), no_errors!
+      expect_that (-> T '() -> nil', {}), errors matches 'incorrect type: expected function but got table'
 
 -- import set_log_verbosity from require 'fat.logger'
 -- set_log_verbosity true

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -359,8 +359,9 @@ class List
       [] = C_PUSH
       [] = 1
 
-      loop_start = #prog
       [] = C_GET_FIELD
+      loop_start = #prog
+
       [] = C_JMP_IF_NIL
       [] = LABEL_PLACEHOLDER
       loop_exit_jump_index = #prog
@@ -690,6 +691,20 @@ spec ->
       expect_that (-> T '?number', 123), no_errors!
       expect_that (-> T '?number', 'str'), errors matches 'incorrect type: expected number but got string'
       expect_that (-> T '?(number)', 'str'), errors matches 'incorrect type: expected table but got string'
+
+    it 'checks lists', ->
+      expect_that (-> T '[number]', {}), no_errors!
+      expect_that (-> T '[number]', {123, 312}), no_errors!
+      expect_that (-> T '[[number]]', {{123}, {312}}), no_errors!
+
+      expect_that (-> T '[string]', 123), errors matches 'incorrect type: expected table but got number'
+      expect_that (-> T '[string]', {field: 456}), errors matches 'incorrect type: expected string but got number'
+
+      hybrid = {123, 456, 789, field: 'a'}
+      if #hybrid != 3
+        expect_that (-> T '[string]', hybrid), no_errors!
+      else
+        expect_that (-> T '[string]', hybrid), errors matches 'incorrect type: expected string but got number'
 
     it 'checks tuples', ->
       expect_that (-> T '()', {}), no_errors!

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -602,7 +602,7 @@ check = (check_prog, value) ->
             pc = [pc + 1] - 1
         else
           check_error "internal error: illegal type-checker VM instruction #{[pc]}@#{pc}"
-  if true -- DEBUG
+  if DEBUG
     print "FINAL stack state #{check_prog[pc]}@#{pc} [#{stack_size}]:\n\t#{table.concat [ "#{i}:\t#{repr stack[i]}" for i = 1, stack_size], '\n\t'}"
   assert stack_size == 1, "internal error: value stack is not 1"
   stack[1] = nil

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -835,6 +835,7 @@ checker_program_repr = (checker) ->
 
 LABEL_PLACEHOLDER = <tostring>: => '<LABEL-PLACEHOLDER>'
 
+export MAX_CHECKER_DEPTH = 1000
 stack_size = 0
 stack = {}
 num_unions = 0
@@ -843,8 +844,6 @@ union_bail_jumps = {}
 root_union = nil
 num_running_checkers = 0
 instruction_counts = {}
-
-export MAX_CHECKER_DEPTH = 1000
 check = (check_prog, value, root=true) ->
   if root
     -- Prime stack.

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -294,8 +294,6 @@ named_type = (name) ->
 class Primitive
   new: (@name) =>
 
-  __len: => #@name
-
   __tostring: => @name
 
 class UserType

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -56,7 +56,7 @@ class Lexer
     @tokens = coroutine.wrap ->
       original_type_spec = type_spec
       while #type_spec > 0
-        token_type, token_value = if whitespace = type_spec\match '^[ \t\r\n]'
+        token_type, value = if whitespace = type_spec\match '^[ \t\r\n]'
           nil, whitespace
         else if type_spec\match '^%('
           PAREN_OPEN, '('
@@ -79,9 +79,14 @@ class Lexer
         else
           error "unrecognised character '#{type_spec\sub 1, 1}' in type spec '#{original_type_spec}"
 
-        type_spec = type_spec\sub #token_value + 1
-        if token_type?
-          coroutine.yield { :token_type, :token_value }
+        type_spec = type_spec\sub #value + 1
+        switch token_type
+          when nil
+            continue -- continue
+          when NAME
+            coroutine.yield { :token_type, :value }
+          else
+            coroutine.yield { :token_type }
 
   peek: =>
     if @done
@@ -127,28 +132,28 @@ spec ->
         * type ""
       for simple_type in *simple_types
         expect_that (tokens simple_type), deep_eq {
-          { token_type: NAME, token_value: simple_type },
+          { token_type: NAME, value: simple_type },
         }
 
     it 'emits strucural tokens', ->
       expect_that (tokens '(),{}[]->'), deep_eq {
-        { token_type: PAREN_OPEN, token_value: '(' },
-        { token_type: PAREN_CLOSE, token_value: ')' },
-        { token_type: COMMA, token_value: ',' },
-        { token_type: BRACE_OPEN, token_value: '{' },
-        { token_type: BRACE_CLOSE, token_value: '}' },
-        { token_type: BRACKET_OPEN, token_value: '[' },
-        { token_type: BRACKET_CLOSE, token_value: ']' },
-        { token_type: ARROW, token_value: '->' },
+        { token_type: PAREN_OPEN },
+        { token_type: PAREN_CLOSE },
+        { token_type: COMMA },
+        { token_type: BRACE_OPEN },
+        { token_type: BRACE_CLOSE },
+        { token_type: BRACKET_OPEN },
+        { token_type: BRACKET_CLOSE },
+        { token_type: ARROW },
       }
 
     it 'ignores whitespace', ->
       expect_that (tokens ' (\tstring\r)\n-> string '), deep_eq {
-        { token_type: PAREN_OPEN, token_value: "(" },
-        { token_type: NAME, token_value: "string" },
-        { token_type: PAREN_CLOSE, token_value: ")" },
-        { token_type: ARROW, token_value: "->" },
-        { token_type: NAME, token_value: "string" },
+        { token_type: PAREN_OPEN },
+        { token_type: NAME, value: "string" },
+        { token_type: PAREN_CLOSE },
+        { token_type: ARROW },
+        { token_type: NAME, value: "string" },
       }
 
     it 'rejects unrecognised characters', ->
@@ -158,12 +163,12 @@ spec ->
     describe ':peek', ->
       it 'matches :next', ->
         lexer = Lexer '()'
-        assert_that lexer\peek!, deep_eq { token_type: PAREN_OPEN, token_value: '('}
-        assert_that lexer\peek!, deep_eq { token_type: PAREN_OPEN, token_value: '('}
-        assert_that lexer\next!, deep_eq { token_type: PAREN_OPEN, token_value: '('}
-        assert_that lexer\peek!, deep_eq { token_type: PAREN_CLOSE, token_value: ')'}
-        assert_that lexer\peek!, deep_eq { token_type: PAREN_CLOSE, token_value: ')'}
-        assert_that lexer\next!, deep_eq { token_type: PAREN_CLOSE, token_value: ')'}
+        assert_that lexer\peek!, deep_eq { token_type: PAREN_OPEN }
+        assert_that lexer\peek!, deep_eq { token_type: PAREN_OPEN }
+        assert_that lexer\next!, deep_eq { token_type: PAREN_OPEN }
+        assert_that lexer\peek!, deep_eq { token_type: PAREN_CLOSE }
+        assert_that lexer\peek!, deep_eq { token_type: PAREN_CLOSE }
+        assert_that lexer\next!, deep_eq { token_type: PAREN_CLOSE }
 
       it 'returns nil on empty peek', ->
         lexer = Lexer ''

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -761,7 +761,8 @@ export declare_type = (name, type_spec) ->
   type_checkers[name] = parsed_type\checker!\build!
 
 export deactivate = ->
-  T = (_, fn) -> fn
+  T = (_, value) -> value
+  F = (_, fn) ->
 
 export stats = ->
   stats_arr = [:instruction, :count for instruction, count in pairs instruction_counts]

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -717,9 +717,7 @@ check = (check_prog, value, root=true) ->
         when C_JMP
           pc = [pc + 1] - 2
         when C_JMP_IF_NIL
-          if stack[stack_size]?
-            -- No branch.
-          else
+          if not stack[stack_size]?
             pc = [pc + 1] - 2
         when C_PUSH_CHECKER
           arg = [pc + 1]

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -140,7 +140,14 @@ class TypeSpecParser extends Parser
     ret
 
   parse_type: =>
-    @parse_type_conjunction!
+    @parse_type_disjunction!
+
+  parse_type_disjunction: =>
+    disjunction = @parse_repeat_separated @\parse_type_conjunction, T_PIPE
+    if #disjunction == 1
+      disjunction[1] -- Single element
+    else
+      Disjunction disjunction
 
   parse_type_conjunction: =>
     conjunction = @parse_repeat_separated @\parse_optional_type, T_PLUS
@@ -294,6 +301,7 @@ T_COLON = <tostring>: => "':'"
 T_ARROW = <tostring>: => "'->'"
 T_QUESTION = <tostring>: => "'?'"
 T_PLUS = <tostring>: => "'+'"
+T_PIPE = <tostring>: => "'|'"
 T_NAME = <tostring>: => "<name>"
 T_STRING = <tostring>: => "<string>"
 
@@ -332,6 +340,8 @@ class Lexer
           T_QUESTION, nil, #match
         else if match = type_spec\match '^+', @index
           T_PLUS, nil, #match
+        else if match = type_spec\match '^|', @index
+          T_PIPE, nil, #match
         else if name = type_spec\match '^([a-zA-Z_][a-zA-Z0-9_]*)', @index
           T_NAME, name, #name
         else if string = type_spec\match [[^"([^"]*)"]], @index
@@ -623,6 +633,12 @@ class Function
     with checker_builder
       \add C_ASSERT_PRIMITIVE, 'function'
 
+class Disjunction
+  new: (@types) =>
+
+  __tostring: =>
+    table.concat [tostring ty for ty in *@types], '|'
+
 class Conjunction
   new: (@types) =>
 
@@ -875,7 +891,7 @@ spec ->
       }
 
     it 'emits strucural tokens', ->
-      expect_that (tokens '(),{}[]:->?+'), deep_eq {
+      expect_that (tokens '(),{}[]:->?+|'), deep_eq {
         Symbol T_PAREN_OPEN
         Symbol T_PAREN_CLOSE
         Symbol T_COMMA
@@ -887,6 +903,7 @@ spec ->
         Symbol T_ARROW
         Symbol T_QUESTION
         Symbol T_PLUS
+        Symbol T_PIPE
       }
 
     it 'ignores whitespace', ->
@@ -998,6 +1015,25 @@ spec ->
           * Mapping (Primitive 'number'), Primitive 'string'
           * Primitive 'table'
           * Primitive 'function'
+
+      it 'accepts disjunctions', ->
+        expect_that (parse '[string]|{number->string}|table|function'), deep_eq Disjunction
+          * Array Primitive 'string'
+          * Mapping (Primitive 'number'), Primitive 'string'
+          * Primitive 'table'
+          * Primitive 'function'
+
+      it 'gives precedence to conjunctions', ->
+        expect_that (parse 'string+number|boolean'), deep_eq Disjunction
+          * Conjunction
+            * Primitive 'string'
+            * Primitive 'number'
+          * Primitive 'boolean'
+        expect_that (parse 'string|number+boolean'), deep_eq Disjunction
+          * Primitive 'string'
+          * Conjunction
+            * Primitive 'number'
+            * Primitive 'boolean'
 
   describe 'T', ->
     it 'requires two arguments', ->

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -1046,7 +1046,7 @@ spec ->
       expect_that (-> (F '(string) -> table', ->) 'a', 'b'), errors matches 'function passed too many arguments'
 
     it 'rejects incorrect-type return values', ->
-      expect_that (-> (F '(table) -> string', ->) {}), errors matches 'incorrect type: expected string but got number'
+      expect_that (-> (F '(table) -> string', ->) {}), errors matches 'incorrect type: expected string but got nil'
 
     it 'rejects extra return arguments', ->
       expect_that (-> (F '() -> string', -> 'a', 'b')!), errors matches 'function returned too many values'

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -45,6 +45,15 @@ class Parser
       error "expected #{expected_token}"
     token.value ?? token.type
 
+  maybe: (expected_token) =>
+    token = @lexer\peek!
+    if not token?
+      return nil
+    if token.type != expected_token
+      return nil
+    @lexer\next!
+    token.value ?? token.type
+
   select: (options) =>
     next_token = @lexer\peek!
 
@@ -105,12 +114,14 @@ class TypeSpecParser extends Parser
       * token: T_BRACKET_CLOSE
     List elem_type
 
-  parse_tuple: =>
-    {_, elem_types, _} = @sequence
-      * token: T_PAREN_OPEN
+  parse_tuple_or_function: =>
+    @expect T_PAREN_OPEN
+    if @maybe T_PAREN_CLOSE
+      return Tuple {}
+    {types, _} = @sequence
       * action: -> @parse_repeat_separated @\parse_type, T_COMMA
       * token: T_PAREN_CLOSE
-    Tuple elem_types
+    Tuple types
 
   parse_table: =>
     {_, table, _} = @sequence
@@ -568,6 +579,7 @@ spec ->
         expect_that (parse '[[string]]'), deep_eq List List Primitive 'string'
 
       it 'accepts tuples', ->
+        expect_that (parse '()'), deep_eq Tuple {}
         expect_that (parse '(nil, number)'), deep_eq Tuple { (Primitive 'nil'), Primitive 'number' }
         expect_that (parse '((nil, number), string, (Custom, table))'), deep_eq Tuple {
           Tuple { (Primitive 'nil'), (Primitive 'number') },
@@ -618,6 +630,7 @@ spec ->
       expect_that (-> typed 'string', 123), errors matches 'incorrect type: expected string but got number'
 
     it 'checks tuples', ->
+      expect_that (-> typed '()', {}), no_errors!
       expect_that (-> typed '(number, boolean, string)', {123, true, 'hello'}), no_errors!
       expect_that (-> typed '(number, boolean, string)', {123, true, 'hello', coroutine.create ->}), no_errors!
       expect_that (-> typed '((number, boolean), (string, thread))', {{123, true}, {'hello', coroutine.create ->}}), no_errors!

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -20,18 +20,12 @@ export typed = (type_spec, value) ->
   -- checker = type_checker type_spec
   -- print (require 'spec').repr checker
 
--- Non termianls
-NT_TYPE_SPEC = <tostring>: => "type_spec"
-NT_FUNC_SPEC = <tostring>: => "func_spec"
-NT_NONFUNC_SPEC = <tostring>: => "nonfunc_spec"
-NT_LIST = <tostring>: => "list"
-
--- Terminals
+-- Tokens
 T_PAREN_OPEN = <tostring>: => "<paren_open>"
 T_PAREN_CLOSE = <tostring>: => "<paren_close>"
 T_BRACE_OPEN = <tostring>: => "<brace_open>"
 T_BRACE_CLOSE = <tostring>: => "<brace_close>"
-T_BRACKET_OPEN = <tostring>: => "<bracket_close>"
+T_BRACKET_OPEN = <tostring>: => "<bracket_open>"
 T_BRACKET_CLOSE = <tostring>: => "<bracket_close>"
 T_COMMA = <tostring>: => "<comma>"
 T_ARROW = <tostring>: => "<arrow>"
@@ -42,84 +36,78 @@ type_checker = (type_spec) ->
   {} -- TODO(kcza): complete me!
 
 parse = (type_spec) ->
-  type_spec_parser = Parser
-    root_symbol: NT_TYPE_SPEC,
-    rules:
-      * produces: NT_TYPE_SPEC
-        patterns:
-          * pattern: { NT_NONFUNC_SPEC }
-      * produces: NT_NONFUNC_SPEC
-        patterns:
-          * pattern: { T_NAME }
-          * pattern: { NT_LIST }
-      * produces: NT_LIST
-        patterns:
-          * pattern: { T_BRACKET_OPEN, NT_TYPE_SPEC, T_BRACKET_CLOSE }
-            action: (_, elem_type, _) -> List elem_type
-  type_spec_parser\parse type_spec
+  type_spec_parser = Parser Lexer type_spec
+  type_spec_parser\parse!
 
 class Parser
-  new: (config) =>
-    { :root_symbol, rules: raw_rules } = config
-    @root_symbol = root_symbol
-    @rules = with {}
-      for { :produces, :patterns } in *raw_rules
-        for { :pattern, :action } in *patterns
-          if pattern == nil or #pattern == 0
-            error "cannot construct rules: pattern missing"
-          if not action? and #pattern != 1
-            error "cannot construct rules: implicit action only available on single-symbol patterns"
-          [] = { :produces, :pattern, :action }
+  new: (@lexer) =>
 
-  parse: (type_spec) =>
-    lexer = Lexer type_spec
+  parse: =>
+    @parse_type!
 
-    stack = {lexer\next!}
-    while #stack > 0
-      done = @step lexer, stack
-      if done
-        break
-    stack[1].value
+  parse_type: =>
+    @select
+      * token: T_NAME
+        action: @\parse_name
+      * token: T_BRACKET_OPEN
+        action: @\parse_list
+      * token: T_PAREN_OPEN
+        action: @\parse_tuple
 
-  step: (lexer, stack) =>
-    print "======= STEP stack is #{repr stack} ======="
-    for rule in *@rules
-      if @try_reduce rule, stack
-        print "reduced #{repr rule.produces} <- #{repr rule.pattern}"
-        return #stack == 1 and stack[1].type == @root_symbol
+  parse_name: =>
+    name_token = @lexer\next!
+    assert T_NAME == name_token.type
+    name_token.value
 
-    token = lexer\next!
+  parse_list: =>
+    {_, elem_type, _} = @sequence
+      * token: T_BRACKET_OPEN
+      * action: @\parse_type
+      * token: T_BRACKET_CLOSE
+    List elem_type
+
+  parse_tuple: =>
+    {_, elem_types, _} = @sequence
+      * token: T_PAREN_OPEN
+      * action: -> @parse_repeat_separated @\parse_type, T_COMMA
+      * token: T_PAREN_CLOSE
+    Tuple elem_types
+
+  parse_repeat_separated: (elem_parser, sep_token) =>
+    with {}
+      [] = elem_parser!
+      while @lexer\peek!.type == sep_token
+        @lexer\next!
+        [] = elem_parser!
+
+  expect: (expected_token) =>
+    token = @lexer\next!
     if not token?
       error "unexpected EOF"
-    @shift token, stack
-    false
+    if token.type != expected_token
+      error "expected #{expected_token}"
+    token.value ?? 0
 
-  shift: (token, stack) =>
-    stack[] = token
+  select: (options) =>
+    next_token = @lexer\peek!
+    for option in *options
+      if option.token == next_token.type
+        return option.action!
+    options_repr = table.concat [ tostring option.token for option in *options ], ', '
+    error "expected one of #{options_repr}, got #{next_token.type}"
 
-  try_reduce: (rule, stack) =>
-    { :produces, :pattern, :action } = rule
-
-    -- Check reduction possible
-    if #stack < #pattern
-      return false
-    for i = 1, #pattern
-      if stack[#stack - #pattern + i].type != pattern[i]
-        return false
-
-    -- Reduce.
-    reduced_values = with {}
-      for i = #stack - #pattern + 1, #stack
-        [] = stack[i].value
-        stack[i] = nil
-    value = if action?
-      action unpack value
-    else
-      assert #reduced_values == 1
-      reduced_values[1]
-    print repr Symbol produces, value
-    stack[] = Symbol produces, value
-    true
+  sequence: (expected_tokens) =>
+    with {}
+      for { token: expected_token, :action } in *expected_tokens
+        if expected_token?
+          token = @lexer\next!
+          if not token?
+            error "unexpected EOF"
+          if token.type != expected_token
+            error "expected #{expected_token}, got #{token.type}"
+          [] = token.value ?? 0
+        else if action?
+          [] = action!
 
 class Lexer
   new: (type_spec) =>
@@ -134,37 +122,37 @@ class Lexer
       table: true
       thread: true
     @tokens = coroutine.wrap ->
-      original_type_spec = type_spec
-      while #type_spec > 0
-        ty, value, bytes_consumed = if whitespace = type_spec\match '^[ \t\r\n]'
+      index = 1
+      while index <= #type_spec
+        ty, value, bytes_consumed = if whitespace = type_spec\match '^[ \t\r\n]+', index
           nil, whitespace, #whitespace
-        else if type_spec\match '^%('
+        else if type_spec\match '^%(', index
           T_PAREN_OPEN, '(', 1
-        else if type_spec\match '^%)'
+        else if type_spec\match '^%)', index
           T_PAREN_CLOSE, ')', 1
-        else if type_spec\match '^,'
+        else if type_spec\match '^,', index
           T_COMMA, ',', 1
-        else if type_spec\match '^{'
+        else if type_spec\match '^{', index
           T_BRACE_OPEN, '{', 1
-        else if type_spec\match '^}'
+        else if type_spec\match '^}', index
           T_BRACE_CLOSE, '}', 1
-        else if type_spec\match '^%['
+        else if type_spec\match '^%[', index
           T_BRACKET_OPEN, '[', 1
-        else if type_spec\match '^]'
+        else if type_spec\match '^]', index
           T_BRACKET_CLOSE, ']', 1
-        else if type_spec\match '^->'
+        else if type_spec\match '^->', index
           T_ARROW, '->', 2
-        else if name = type_spec\match '^([a-zA-Z_][a-zA-Z0-9_]*)'
+        else if name = type_spec\match '^([a-zA-Z_][a-zA-Z0-9_]*)', index
           if @known_primitives[name]?
             T_NAME, (Primitive name), #name
-          else if (name\sub 1, 1)\match '^[a-z]$'
-            error "type '#{name}' is not a Lua primitive"
+          else if not name\match '^[A-Z]'
+            error "cannot use '#{name}' as custom type name: name must start with an uppercase letter"
           else
             T_NAME, (UserType name), #name
         else
-          error "unrecognised character '#{type_spec\sub 1, 1}' in type spec '#{original_type_spec}"
+          error "unrecognised character '#{type_spec\sub index, index}' in type spec '#{type_spec}"
 
-        type_spec = type_spec\sub bytes_consumed + 1
+        index += bytes_consumed
         switch ty
           when nil
             continue
@@ -225,6 +213,13 @@ class List
 
   __tostring: =>
     "[#{@elem_type}]"
+
+class Tuple
+  new: (@elem_types) =>
+
+  __tostring: =>
+    elem_type_reprs = [ tostring elem_type for elem_type in *@elem_types ]
+    "(#{table.concat elem_type_reprs, ', '})"
 
 class Function
   new: (@param_types, @return_types) =>
@@ -342,11 +337,20 @@ spec ->
         expect_that (parse 'CustomType'), deep_eq UserType 'CustomType'
 
       it 'rejects unknown primitives', ->
-        expect_that (-> parse 'custom'), errors matches [[type 'custom' is not a Lua primitive]]
+        expect_that (-> parse 'custom'), errors matches [[cannot use 'custom' as custom type name: name must start with an uppercase letter]]
 
-    -- describe 'run on compositetypes', ->
-    --   it 'accepts lists', ->
-    --     expect_that (type_checker '[]')
+    describe 'run on composite types', ->
+      it 'accepts lists', ->
+        expect_that (parse '[string]'), deep_eq List Primitive 'string'
+        expect_that (parse '[[string]]'), deep_eq List List Primitive 'string'
+
+      it 'accepts tuples', ->
+        expect_that (parse '(nil, number)'), deep_eq Tuple { (Primitive 'nil'), Primitive 'number' }
+        expect_that (parse '((nil, number), string, (Custom, table))'), deep_eq Tuple {
+          Tuple { (Primitive 'nil'), (Primitive 'number') },
+          Primitive 'string',
+          Tuple { (UserType 'Custom'), (Primitive 'table') },
+        }
 
   describe 'declare_type', ->
     it 'rejects false primitives', ->
@@ -368,8 +372,6 @@ spec ->
   --     expect_that (-> typed 'number', nil), errors anything!
   --     expect_that (-> typed 'number', 123), no_errors!
 
-import set_log_verbosity from require 'fat.logger'
+-- import set_log_verbosity from require 'fat.logger'
 -- set_log_verbosity true
 (require 'spec').run_tests select 1, ...
-
--- print 'type checker:', type_checker 'boolean'

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -432,7 +432,6 @@ class Tuple
         \add C_GET_FIELD
         @elem_types[i]\checker checker_builder
         \add C_POP
-        \add C_INCR
         \add C_POP
 
 class Struct

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -9,6 +9,7 @@ export T = (type_spec, value) ->
 
   checker = type_checker type_spec
   check checker, value
+  value
 
 export DEBUG = false
 export COLLECT_STATS = false
@@ -847,6 +848,10 @@ spec ->
   describe 'T', ->
     it 'requires two arguments', ->
       expect_that (-> T!), errors matches 'cannot typecheck: no type spec provided'
+
+    it 'returns its second argument', ->
+      value = {}
+      expect_that (T '{}', value), eq value
 
     it 'checks primitives', ->
       expect_that (-> T 'nil', nil), no_errors!

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -294,7 +294,7 @@ class Primitive
 
   checker: (prog={}) =>
     with prog
-      [] = C_PRIMITIVE
+      [] = C_ASSERT_PRIMITIVE
       [] = @name
 
 class UserType
@@ -302,11 +302,36 @@ class UserType
 
   __tostring: => @name
 
+  checker: (prog={}) =>
+    error 'todo'
+
 class List
   new: (@elem_type) =>
 
   __tostring: =>
     "[#{@elem_type}]"
+
+  checker: (prog={}) =>
+    with prog
+      [] = C_ASSERT_PRIMITIVE
+      [] = 'table'
+      [] = C_PUSH
+      [] = 1
+
+      loop_start = #prog
+      [] = C_GET_FIELD
+      [] = C_JMP_IF_NIL
+      [] = 10101010
+      loop_exit_jump_index = #prog
+      @elem_type\checker prog
+      [] = C_POP
+      [] = C_INCR
+      [] = C_JMP
+      [] = loop_start
+
+      [] = C_POP -- TODO(kcza): check stack on early exit
+      [loop_exit_jump_index] = #prog
+
 
 class Tuple
   new: (@elem_types) =>
@@ -317,12 +342,15 @@ class Tuple
 
   checker: (prog={}) =>
     with prog
-      [] = C_PRIMITIVE
+      [] = C_ASSERT_PRIMITIVE
       [] = 'table'
       for i = 1, #@elem_types
         [] = C_PUSH
         [] = i
+        [] = C_GET_FIELD
         @elem_types[i]\checker prog
+        [] = C_POP
+        [] = C_INCR
         [] = C_POP
 
 class Struct
@@ -334,12 +362,14 @@ class Struct
 
   checker: (prog={}) =>
     with prog
-      [] = C_PRIMITIVE
+      [] = C_ASSERT_PRIMITIVE
       [] = 'table'
       for field in *@fields
         [] = C_PUSH
         [] = field.name
+        [] = C_GET_FIELD
         field.type\checker prog
+        [] = C_POP
         [] = C_POP
 
 class Field
@@ -357,11 +387,17 @@ class Set
   __tostring: =>
     "{#{@elem_type}}"
 
+  checker: (prog={}) =>
+    error 'todo'
+
 class Mapping
   new: (@in_type, @out_type) =>
 
   __tostring: =>
     "{#{@in_type} -> #{@out_type}}"
+
+  checker: (prog={}) =>
+    error 'todo'
 
 class Function
   new: (@param_types, @return_types) =>
@@ -389,9 +425,16 @@ class Function
           [] = tostring return_type
         [] = '>'
 
-C_PRIMITIVE = <tostring>: => 'PRIMITIVE'
-C_PUSH = <tostring>: => 'PUSH'
-C_POP = <tostring>: => 'POP'
+  checker: (prog={}) =>
+    error 'todo'
+
+C_PUSH = <tostring>: => '<push>'
+C_POP = <tostring>: => '<pop>'
+C_ASSERT_PRIMITIVE = <tostring>: => '<assert-primitive>'
+C_GET_FIELD = <tostring>: => '<field>'
+C_INCR = <tostring>: => '<incr>'
+C_JMP = <tostring>: => '<jmp>'
+C_JMP_IF_NIL = <tostring>: => '<jnil>'
 
 value_stack_size = 0
 value_stack = {}
@@ -401,19 +444,31 @@ check = (check_prog, value) ->
 
   for pc = 1, #check_prog
     switch check_prog[pc]
-      when C_PRIMITIVE
+      when C_PUSH
+        pc += 1
+        value = check_prog[pc]
+        value_stack_size += 1
+        value_stack[value_stack_size] = value
+      when C_POP
+        value_stack[value_stack_size] = nil
+        value_stack_size -= 1
+      when C_ASSERT_PRIMITIVE
         ty = type value_stack[value_stack_size]
         pc += 1
         if ty != check_prog[pc]
           error "incorrect type: expected #{check_prog[pc]} but got #{ty}"
-      when C_PUSH
-        pc += 1
-        field = value_stack[value_stack_size][check_prog[pc]]
+      when C_GET_FIELD
         value_stack_size += 1
-        value_stack[value_stack_size] = field
-      when C_POP
-        value_stack[value_stack_size] = nil
-        value_stack_size -= 1
+        value_stack[value_stack_size] = value_stack[value_stack_size-2][value_stack[value_stack_size-1]]
+      when C_INCR
+        value_stack[value_stack_size] += 1
+      when C_JMP
+        pc = chec_prog[pc + 1] - 1
+      when C_JMP_IF_NIL
+        if value_stack[value_stack_size]?
+          pc = chec_prog[pc] - 1
+        else
+          pc += 1
 
 export declare_type = (name, type_spec) ->
   if not (name\sub 1, 1)\match '^[A-Z_]$'
@@ -578,6 +633,7 @@ spec ->
       expect_that (-> typed '{}', {hello: 123}), no_errors!
       expect_that (-> typed '{hello: string}', {hello: 'hello'}), no_errors!
       expect_that (-> typed '{hello: {world: string}}', {hello: world: 'world'}), no_errors!
+      expect_that (-> typed '{hello: {world: string}, foo: boolean}', hello: {world:'asdf'}, foo: true), no_errors!
 
       expect_that (-> typed '{}', 132), errors matches 'incorrect type: expected table but got number'
       expect_that (-> typed '{hello: string}', {}), errors matches 'incorrect type: expected string but got nil'
@@ -585,6 +641,7 @@ spec ->
       expect_that (-> typed '{hello: {world: string}}', hello: 123), errors matches 'incorrect type: expected table but got number'
       expect_that (-> typed '{hello: {world: string}}', hello: {}), errors matches 'incorrect type: expected string but got nil'
       expect_that (-> typed '{hello: {world: string}}', hello: world: 123), errors matches 'incorrect type: expected string but got number'
+      expect_that (-> typed '{hello: {world: string}, foo: boolean}', hello: {world:'asdf'}, foo: 123), errors matches 'incorrect type: expected boolean but got number'
 
 -- import set_log_verbosity from require 'fat.logger'
 -- set_log_verbosity true

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -73,9 +73,11 @@ class Parser
   parse_repeat_separated: (elem_parser, sep_token) =>
     with {}
       [] = elem_parser!
-      while @lexer\peek!.type == sep_token
+      tok = @lexer\peek!
+      while tok? and tok.type == sep_token
         @lexer\next!
         [] = elem_parser!
+        tok = @lexer\peek!
 
   expect: (expected_token) =>
     token = @lexer\next!
@@ -138,11 +140,26 @@ class TypeSpecParser extends Parser
     ret
 
   parse_type: =>
-    handle_optional = if @maybe T_QUESTION
-      (elem_type) -> Optional elem_type
+    @parse_type_conjunction!
+
+  parse_type_conjunction: =>
+    conjunction = @parse_repeat_separated @\parse_optional_type, T_PLUS
+    if #conjunction == 1
+      conjunction[1] -- Single element
     else
-      (...) -> ...
-    handle_optional @select
+      Conjunction conjunction
+
+  parse_optional_type: =>
+    @select
+      * token: T_QUESTION
+        action: ->
+          @expect T_QUESTION
+          Optional @parse_specific_type!
+      otherwise: ->
+        @parse_specific_type!
+
+  parse_specific_type: =>
+    @select
       * token: T_NAME
         action: @\parse_named_type
       * token: T_STRING
@@ -276,6 +293,7 @@ T_COMMA = <tostring>: => "','"
 T_COLON = <tostring>: => "':'"
 T_ARROW = <tostring>: => "'->'"
 T_QUESTION = <tostring>: => "'?'"
+T_PLUS = <tostring>: => "'+'"
 T_NAME = <tostring>: => "<name>"
 T_STRING = <tostring>: => "<string>"
 
@@ -312,6 +330,8 @@ class Lexer
           T_ANGLE_CLOSE, nil, #match
         else if match = type_spec\match '^?', @index
           T_QUESTION, nil, #match
+        else if match = type_spec\match '^+', @index
+          T_PLUS, nil, #match
         else if name = type_spec\match '^([a-zA-Z_][a-zA-Z0-9_]*)', @index
           T_NAME, name, #name
         else if string = type_spec\match [[^"([^"]*)"]], @index
@@ -603,6 +623,17 @@ class Function
     with checker_builder
       \add C_ASSERT_PRIMITIVE, 'function'
 
+class Conjunction
+  new: (@types) =>
+
+  __tostring: =>
+    table.concat [tostring ty for ty in *@types], '+'
+
+  checker: (checker_builder=CheckerBuilder!) =>
+    with checker_builder
+      for ty in *@types
+        ty\checker checker_builder
+
 class CheckerBuilder
   new: =>
     @instructions = {}
@@ -844,7 +875,7 @@ spec ->
       }
 
     it 'emits strucural tokens', ->
-      expect_that (tokens '(),{}[]:->?'), deep_eq {
+      expect_that (tokens '(),{}[]:->?+'), deep_eq {
         Symbol T_PAREN_OPEN
         Symbol T_PAREN_CLOSE
         Symbol T_COMMA
@@ -855,6 +886,7 @@ spec ->
         Symbol T_COLON
         Symbol T_ARROW
         Symbol T_QUESTION
+        Symbol T_PLUS
       }
 
     it 'ignores whitespace', ->
@@ -960,6 +992,13 @@ spec ->
         expect_that (parse '() -> <string>'), deep_eq Function {}, {(Primitive 'string')}
         expect_that (parse '() -> <string, boolean>'), deep_eq Function {}, {(Primitive 'string'), (Primitive 'boolean')}
 
+      it 'accepts conjunctions', ->
+        expect_that (parse '[string]+{number->string}+table+function'), deep_eq Conjunction
+          * Array Primitive 'string'
+          * Mapping (Primitive 'number'), Primitive 'string'
+          * Primitive 'table'
+          * Primitive 'function'
+
   describe 'T', ->
     it 'requires two arguments', ->
       expect_that (-> T!), errors matches 'cannot typecheck: no type spec provided'
@@ -1050,6 +1089,12 @@ spec ->
       expect_that (-> T '() -> nil', ->), no_errors!
       expect_that (-> T '() -> nil', -> nil), no_errors!
       expect_that (-> T '() -> nil', {}), errors matches 'incorrect type: expected function but got table'
+
+    it 'checks conjunctions', ->
+      expect_that (-> T '[string]+{number}', {'a', 'b', 'c'}), no_errors!
+
+      expect_that (-> T 'string+number', 123), errors matches 'incorrect type: expected string but got number'
+      expect_that (-> T 'string+number', 'hello'), errors matches 'incorrect type: expected number but got string'
 
   describe 'declare_type', ->
     it 'requires two arguments', ->

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -296,12 +296,12 @@ class Primitive
 
   __len: => #@name
 
-  __tostring: => 'P' .. @name
+  __tostring: => @name
 
 class UserType
   new: (@name) =>
 
-  __tostring: => 'U' .. @name
+  __tostring: => @name
 
 class List
   new: (@elem_type) =>

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -61,6 +61,8 @@ class Parser
 
   select: (options) =>
     next_token = @lexer\peek!
+    if not next_token?
+      error "unexpected EOF"
 
     i = 1
     while options[i]
@@ -95,7 +97,10 @@ class Parser
 
 class TypeSpecParser extends Parser
   parse: =>
-    @parse_type!
+    ret = @parse_type!
+    if @lexer\peek!
+      error 'type spec has trailing characters'
+    ret
 
   parse_type: =>
     handle_optional = if @maybe T_QUESTION
@@ -712,6 +717,12 @@ spec ->
 
       it 'rejects unknown primitives', ->
         expect_that (-> parse 'custom'), errors matches [[cannot use 'custom' as custom type name: name must start with an uppercase letter]]
+
+      it 'rejects incomplete types', ->
+        expect_that (-> parse '['), errors matches [[unexpected EOF]]
+
+      it 'rejects inputs with trailing errors', ->
+        expect_that (-> parse 'string]'), errors matches 'type spec has trailing characters'
 
     describe 'run on composite types', ->
       it 'accepts optional', ->

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -10,6 +10,8 @@ export T = (type_spec, value) ->
   checker = type_checker type_spec
   check checker, value
 
+DEBUG = false
+
 type_checkers = {}
 type_checker = (type_spec) ->
   type_checkers[type_spec] ?? do
@@ -19,7 +21,8 @@ type_checker = (type_spec) ->
 
     type_checkers[type_spec] = checker
     validate checker
-    print "got checker:\n#{repr checker}"
+    if DEBUG
+      print "got checker:\n\t#{table.concat ["#{i}:\t#{repr checker[i]}" for i = 1, #checker], '\n\t'}"
     checker
 
 parse = (type_spec) ->
@@ -525,6 +528,8 @@ check = (check_prog, value) ->
     n_instructions = #check_prog
     while pc < n_instructions
       pc += 1
+      if DEBUG
+        print "stack state #{[pc]}@#{pc} [#{value_stack_size}]:\n\t#{table.concat [ "#{i}:\t#{repr value_stack[i]}" for i = 1, value_stack_size], '\n\t'}"
       switch [pc]
         when C_PUSH
           pc += 1
@@ -567,6 +572,8 @@ check = (check_prog, value) ->
             pc = [pc + 1] - 1
         else
           error "internal error: illegal type-checker VM instruction #{[pc]}@#{pc}"
+  if true -- DEBUG
+    print "FINAL stack state #{check_prog[pc]}@#{pc} [#{value_stack_size}]:\n\t#{table.concat [ "#{i}:\t#{repr value_stack[i]}" for i = 1, value_stack_size], '\n\t'}"
 
 export declare_type = (name, type_spec) ->
   if not (name\sub 1, 1)\match '^[A-Z_]$'
@@ -788,5 +795,6 @@ spec ->
 
 -- import set_log_verbosity from require 'fat.logger'
 -- set_log_verbosity true
+DEBUG = true
 (require 'spec').run_tests select 1, ...
 -- TODO(kcza): optional values

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -841,13 +841,12 @@ check = (check_prog, value, root=true) ->
 
   with check_prog
     local pc = -1
-    n_instructions = #check_prog
     while true
       pc += 2
-      if pc >= n_instructions
+      instruction = [pc]
+      if instruction == nil
         break
 
-      instruction = [pc]
       if COLLECT_STATS
         instruction_counts[instruction] = if v = instruction_counts[instruction]
           v + 1

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -414,7 +414,7 @@ class Struct
         [] = C_PUSH
         [] = field.name
         [] = C_GET_FIELD
-        field.type\checker prog
+        field\checker prog
         [] = C_POP
         [] = C_POP
 

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -94,7 +94,11 @@ class TypeSpecParser extends Parser
     @parse_type!
 
   parse_type: =>
-    @select
+    handle_optional = if @maybe T_QUESTION
+      (elem_type) -> Optional elem_type
+    else
+      (...) -> ...
+    handle_optional @select
       * token: T_NAME
         action: @\parse_named_type
       * token: T_BRACKET_OPEN
@@ -203,6 +207,7 @@ T_BRACKET_CLOSE = <tostring>: => "']'"
 T_COMMA = <tostring>: => "','"
 T_COLON = <tostring>: => "':'"
 T_ARROW = <tostring>: => "'->'"
+T_QUESTION = <tostring>: => "'?'"
 T_NAME = <tostring>: => "<name>"
 
 class Lexer
@@ -232,6 +237,8 @@ class Lexer
           T_COLON, nil, #match
         else if match = type_spec\match '^->', @index
           T_ARROW, nil, #match
+        else if match = type_spec\match '^?', @index
+          T_QUESTION, nil, #match
         else if name = type_spec\match '^([a-zA-Z_][a-zA-Z0-9_]*)', @index
           T_NAME, name, #name
         else
@@ -324,6 +331,21 @@ class UserType
   checker: (prog={}) =>
     error 'todo'
 
+class Optional
+  new: (@inner_type) =>
+
+  __tostring: =>
+    "?#{@inner_type}"
+
+  checker: (prog={}) =>
+    with prog
+      [] = C_JMP_IF_NIL
+      [] = LABEL_PLACEHOLDER
+      label_placeholder_index = #prog
+      @inner_type\checker prog
+
+      [label_placeholder_index] = #prog + 1
+
 class List
   new: (@elem_type) =>
 
@@ -349,7 +371,7 @@ class List
       [] = loop_start
 
       [] = C_POP -- TODO(kcza): check stack on early exit
-      [loop_exit_jump_index] = #prog
+      [loop_exit_jump_index] = #prog + 1
 
 
 class Tuple
@@ -495,10 +517,10 @@ check = (check_prog, value) ->
         when C_INCR
           value_stack[value_stack_size] += 1
         when C_JMP
-          pc = chec_prog[pc + 1] - 1
+          pc = [pc + 1] - 1
         when C_JMP_IF_NIL
           if value_stack[value_stack_size]?
-            pc = chec_prog[pc] - 1
+            pc += 1
           else
             pc = [pc + 1] - 1
 
@@ -537,7 +559,7 @@ spec ->
         }
 
     it 'emits strucural tokens', ->
-      expect_that (tokens '(),{}[]:->'), deep_eq {
+      expect_that (tokens '(),{}[]:->?'), deep_eq {
         Symbol T_PAREN_OPEN
         Symbol T_PAREN_CLOSE
         Symbol T_COMMA
@@ -547,6 +569,7 @@ spec ->
         Symbol T_BRACKET_CLOSE
         Symbol T_COLON
         Symbol T_ARROW
+        Symbol T_QUESTION
       }
 
     it 'ignores whitespace', ->
@@ -595,6 +618,11 @@ spec ->
         expect_that (-> parse 'custom'), errors matches [[cannot use 'custom' as custom type name: name must start with an uppercase letter]]
 
     describe 'run on composite types', ->
+      it 'accepts optional', ->
+        expect_that (parse '?nil'), deep_eq Optional Primitive 'nil'
+        expect_that (parse '?string'), deep_eq Optional Primitive 'string'
+        expect_that (parse '?() -> nil'), deep_eq Optional Function {}, {}
+
       it 'accepts lists', ->
         expect_that (parse '[string]'), deep_eq List Primitive 'string'
         expect_that (parse '[[string]]'), deep_eq List List Primitive 'string'

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -420,11 +420,11 @@ named_type = (name) ->
   else
     UserType name
 
-class Type
+class Is
   is: (ty) =>
     @.<class>.__name == ty.__base.__class.__name
 
-class Primitive extends Type
+class Primitive using Is
   new: (@name) =>
 
   __tostring: => @name
@@ -433,14 +433,14 @@ class Primitive extends Type
     with checker_builder
       \add C_ASSERT_PRIMITIVE, @name
 
-class Any extends Type
+class Any using Is
   __tostring: =>
     'any'
 
   checker: (checker_builder=CheckerBuilder!) =>
     checker_builder -- No checks required.
 
-class UserType extends Type
+class UserType using Is
   new: (@name) =>
 
   __tostring: => @name
@@ -455,7 +455,7 @@ class UserType extends Type
         parsed_user_type\checker checker_builder
         \pop_building @
 
-class StringType extends Type
+class StringType using Is
   new: (@content) =>
 
   __tostring: =>
@@ -466,7 +466,7 @@ class StringType extends Type
       \add C_ASSERT_PRIMITIVE, 'string'
       \add C_ASSERT_EQ, @content
 
-class Optional extends Type
+class Optional using Is
   new: (@inner_type) =>
 
   __tostring: =>
@@ -478,7 +478,7 @@ class Optional extends Type
       @inner_type\checker checker_builder
       inner_skip_target\resolve_here!
 
-class Array extends Type
+class Array using Is
   new: (@elem_type) =>
 
   __tostring: =>
@@ -503,7 +503,7 @@ class Array extends Type
       \add C_ASSERT_LEN
       \add C_POP
 
-class Tuple extends Type
+class Tuple using Is
   new: (@elem_types) =>
 
   __tostring: =>
@@ -520,7 +520,7 @@ class Tuple extends Type
         \add C_POP
         \add C_POP
 
-class Struct extends Type
+class Struct using Is
   new: (@fields) =>
 
   __tostring: =>
@@ -537,7 +537,7 @@ class Struct extends Type
         \add C_POP
         \add C_POP
 
-class Field extends Type
+class Field using Is
   new: (@name, @type) =>
 
   __tostring: =>
@@ -546,7 +546,7 @@ class Field extends Type
   checker: (checker_builder=CheckerBuilder!) =>
     @type\checker checker_builder
 
-class Set extends Type
+class Set using Is
   new: (@elem_type) =>
 
   __tostring: =>
@@ -570,7 +570,7 @@ class Set extends Type
       \add C_POP
       \add C_POP
 
-class Mapping extends Type
+class Mapping using Is
   new: (@in_type, @out_type) =>
 
   __tostring: =>
@@ -596,7 +596,7 @@ class Mapping extends Type
       \add C_POP
 
 
-class Function extends Type
+class Function using Is
   new: (@param_types, @return_types) =>
     @_param_checkers = nil
     @_return_checkers = nil
@@ -646,13 +646,13 @@ class Function extends Type
     with checker_builder
       \add C_ASSERT_PRIMITIVE, 'function'
 
-class Disjunction extends Type
+class Disjunction using Is
   new: (@types) =>
 
   __tostring: =>
     table.concat [tostring ty for ty in *@types], '|'
 
-class Conjunction extends Type
+class Conjunction using Is
   new: (@types) =>
 
   __tostring: =>

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -38,105 +38,140 @@ T_ARROW = <tostring>: => "<arrow>"
 T_NAME = <tostring>: => "<name>"
 
 type_checker = (type_spec) ->
+  parsed_type = parse type_spec
+  {} -- TODO(kcza): complete me!
+
+parse = (type_spec) ->
   type_spec_parser = Parser
-    * produces: NT_TYPE_SPEC
-      patterns:
-        * { NT_NONFUNC_SPEC }
-    * produces: NT_NONFUNC_SPEC
-      patterns:
-        * { T_NAME }
-        * { NT_LIST }
-    * produces: NT_LIST
-      patterns:
-        * { T_BRACKET_OPEN, NT_TYPE_SPEC, T_BRACKET_CLOSE }
+    root_symbol: NT_TYPE_SPEC,
+    rules:
+      * produces: NT_TYPE_SPEC
+        patterns:
+          * pattern: { NT_NONFUNC_SPEC }
+      * produces: NT_NONFUNC_SPEC
+        patterns:
+          * pattern: { T_NAME }
+          * pattern: { NT_LIST }
+      * produces: NT_LIST
+        patterns:
+          * pattern: { T_BRACKET_OPEN, NT_TYPE_SPEC, T_BRACKET_CLOSE }
+            action: (_, elem_type, _) -> List elem_type
   type_spec_parser\parse type_spec
-  {}
 
 class Parser
-  new: (raw_rules) =>
+  new: (config) =>
+    { :root_symbol, rules: raw_rules } = config
+    @root_symbol = root_symbol
     @rules = with {}
       for { :produces, :patterns } in *raw_rules
-        for pattern in *patterns
-          [] = { :produces, :pattern }
-    @stack = nil
+        for { :pattern, :action } in *patterns
+          if pattern == nil or #pattern == 0
+            error "cannot construct rules: pattern missing"
+          if not action? and #pattern != 1
+            error "cannot construct rules: implicit action only available on single-symbol patterns"
+          [] = { :produces, :pattern, :action }
 
   parse: (type_spec) =>
     lexer = Lexer type_spec
 
-    @stack = {}
-    for token in lexer.tokens
-      print "stack is #{repr @stack}"
-      reduced = false
-      for rule in *@rules
-        if @try_reduce rule
-          reduced = true
-          break
-      if not reduced
-        @shift token
-  
-  shift: (token) =>
-    @stack[] = token
-    print "shifted #{repr token}"
+    stack = {lexer\next!}
+    while #stack > 0
+      done = @step lexer, stack
+      if done
+        break
+    stack[1].value
 
-  try_reduce: (rule) =>
-    { :produces, :pattern } = rule
+  step: (lexer, stack) =>
+    print "======= STEP stack is #{repr stack} ======="
+    for rule in *@rules
+      if @try_reduce rule, stack
+        print "reduced #{repr rule.produces} <- #{repr rule.pattern}"
+        return #stack == 1 and stack[1].type == @root_symbol
+
+    token = lexer\next!
+    if not token?
+      error "unexpected EOF"
+    @shift token, stack
+    false
+
+  shift: (token, stack) =>
+    stack[] = token
+
+  try_reduce: (rule, stack) =>
+    { :produces, :pattern, :action } = rule
 
     -- Check reduction possible
-    if #@stack < #pattern
-      print "! no reduction: too short: #{repr pattern}"
+    if #stack < #pattern
       return false
-    for i = 0, #pattern - 1
-      print "! no reduction: mismatch: #{repr pattern}"
-      if @stack[#@stack - i].type != pattern[i]
+    for i = 1, #pattern
+      if stack[#stack - #pattern + i].type != pattern[i]
         return false
 
     -- Reduce.
-    for i = 1, #pattern
-      @stack[#@stack] = nil
-    @stack[] = token
-    print "reduced #{produces} <- #{repr pattern}"
+    reduced_values = with {}
+      for i = #stack - #pattern + 1, #stack
+        [] = stack[i].value
+        stack[i] = nil
+    value = if action?
+      action unpack value
+    else
+      assert #reduced_values == 1
+      reduced_values[1]
+    print repr Symbol produces, value
+    stack[] = Symbol produces, value
     true
 
 class Lexer
   new: (type_spec) =>
-    print "making lexer for #{repr type_spec}"
-
     @done = false
     @peeked = nil
+    @known_primitives =
+      nil: true
+      boolean: true
+      number: true
+      string: true
+      function: true
+      table: true
+      thread: true
     @tokens = coroutine.wrap ->
       original_type_spec = type_spec
       while #type_spec > 0
-        type, value = if whitespace = type_spec\match '^[ \t\r\n]'
-          nil, whitespace
+        ty, value, bytes_consumed = if whitespace = type_spec\match '^[ \t\r\n]'
+          nil, whitespace, #whitespace
         else if type_spec\match '^%('
-          T_PAREN_OPEN, '('
+          T_PAREN_OPEN, '(', 1
         else if type_spec\match '^%)'
-          T_PAREN_CLOSE, ')'
+          T_PAREN_CLOSE, ')', 1
         else if type_spec\match '^,'
-          T_COMMA, ','
+          T_COMMA, ',', 1
         else if type_spec\match '^{'
-          T_BRACE_OPEN, '{'
+          T_BRACE_OPEN, '{', 1
         else if type_spec\match '^}'
-          T_BRACE_CLOSE, '}'
+          T_BRACE_CLOSE, '}', 1
         else if type_spec\match '^%['
-          T_BRACKET_OPEN, '['
+          T_BRACKET_OPEN, '[', 1
         else if type_spec\match '^]'
-          T_BRACKET_CLOSE, ']'
+          T_BRACKET_CLOSE, ']', 1
         else if type_spec\match '^->'
-          T_ARROW, '->'
+          T_ARROW, '->', 2
         else if name = type_spec\match '^([a-zA-Z_][a-zA-Z0-9_]*)'
-          T_NAME, name
+          if @known_primitives[name]?
+            T_NAME, (Primitive name), #name
+          else if (name\sub 1, 1)\match '^[a-z]$'
+            error "type '#{name}' is not a Lua primitive"
+          else
+            T_NAME, (UserType name), #name
         else
           error "unrecognised character '#{type_spec\sub 1, 1}' in type spec '#{original_type_spec}"
 
-        type_spec = type_spec\sub #value + 1
-        switch type
+        type_spec = type_spec\sub bytes_consumed + 1
+        switch ty
           when nil
-            continue -- continue
+            continue
           when T_NAME
-            coroutine.yield { :type, :value }
+            coroutine.yield Symbol ty, value
           else
-            coroutine.yield { :type }
+            coroutine.yield Symbol ty
 
   peek: =>
     if @done
@@ -159,12 +194,67 @@ class Lexer
       @peeked = nil
       peeked
     else
-      @tokens!
+      ret = @tokens!
+      if not ret?
+        @done = true
+      ret
+
+class Symbol
+  new: (@type, @value=nil) =>
+
+  __tostring: =>
+    if @value?
+      "#{@type}(#{@value})"
+    else
+      "#{@type}"
+
+class Primitive
+  new: (@name) =>
+
+  __len: => #@name
+
+  __tostring: => @name
+
+class UserType
+  new: (@name) =>
+
+  __tostring: => @name
+
+class List
+  new: (@elem_type) =>
+
+  __tostring: =>
+    "[#{@elem_type}]"
+
+class Function
+  new: (@param_types, @return_types) =>
+
+  __tostring: =>
+    table.concat with {}
+      [] = '('
+      first = true
+      for param_type in *@param_types
+        if not first
+          [] = ", "
+        first = false
+
+        [] = tostring param_type
+      [] = ') -> '
+      if #@return_types == 1
+        [] = tostring @return_types[1]
+      else
+        [] = '<'
+        first = true
+        for return_type in *@return_types
+          if not first
+            [] = ", "
+          first = false
+          [] = tostring return_type
+        [] = '>'
 
 export declare_type = (name, type_spec) ->
-  first_char = name\sub 1, 1
-  if first_char\upper! != first_char
-    error "cannot declare type '#{name}': custom types must start with uppercase"
+  if not (name\sub 1, 1)\match '^[A-Z_]$'
+    error "cannot declare type '#{name}': custom types must start with uppercase or '_'"
   if type_checkers[name]?
     error "cannot redefine type '#{name}'"
   type_checkers[name] = type_checker name
@@ -174,10 +264,11 @@ export deactivate = ->
 
 spec ->
   import assert_that, expect_that, describe, it, matchers from require 'spec'
-  import anything, deep_eq, eq, errors, match, matches, no_errors from matchers
+  import anything, contains_value, deep_eq, eq, errors, fields, len, match, matches, no_errors from matchers
 
   describe 'Lexer', ->
     tokens = (raw) ->
+      assert raw
       with {}
         for token in (Lexer raw).tokens
           [] = token
@@ -188,30 +279,33 @@ spec ->
         * type false
         * type 0
         * type ""
+        * type ->
+        * type coroutine.create ->
+        * type coroutine.wrap ->
       for simple_type in *simple_types
         expect_that (tokens simple_type), deep_eq {
-          { type: T_NAME, value: simple_type },
+          Symbol T_NAME, Primitive simple_type
         }
 
     it 'emits strucural tokens', ->
       expect_that (tokens '(),{}[]->'), deep_eq {
-        { type: T_PAREN_OPEN },
-        { type: T_PAREN_CLOSE },
-        { type: T_COMMA },
-        { type: T_BRACE_OPEN },
-        { type: T_BRACE_CLOSE },
-        { type: T_BRACKET_OPEN },
-        { type: T_BRACKET_CLOSE },
-        { type: T_ARROW },
+        Symbol T_PAREN_OPEN
+        Symbol T_PAREN_CLOSE
+        Symbol T_COMMA
+        Symbol T_BRACE_OPEN
+        Symbol T_BRACE_CLOSE
+        Symbol T_BRACKET_OPEN
+        Symbol T_BRACKET_CLOSE
+        Symbol T_ARROW
       }
 
     it 'ignores whitespace', ->
       expect_that (tokens ' (\tstring\r)\n-> string '), deep_eq {
-        { type: T_PAREN_OPEN },
-        { type: T_NAME, value: "string" },
-        { type: T_PAREN_CLOSE },
-        { type: T_ARROW },
-        { type: T_NAME, value: "string" },
+        Symbol T_PAREN_OPEN
+        Symbol T_NAME, Primitive "string"
+        Symbol T_PAREN_CLOSE
+        Symbol T_ARROW
+        Symbol T_NAME, Primitive "string"
       }
 
     it 'rejects unrecognised characters', ->
@@ -221,12 +315,12 @@ spec ->
     describe ':peek', ->
       it 'matches :next', ->
         lexer = Lexer '()'
-        assert_that lexer\peek!, deep_eq { type: T_PAREN_OPEN }
-        assert_that lexer\peek!, deep_eq { type: T_PAREN_OPEN }
-        assert_that lexer\next!, deep_eq { type: T_PAREN_OPEN }
-        assert_that lexer\peek!, deep_eq { type: T_PAREN_CLOSE }
-        assert_that lexer\peek!, deep_eq { type: T_PAREN_CLOSE }
-        assert_that lexer\next!, deep_eq { type: T_PAREN_CLOSE }
+        assert_that lexer\peek!, deep_eq Symbol T_PAREN_OPEN
+        assert_that lexer\peek!, deep_eq Symbol T_PAREN_OPEN
+        assert_that lexer\next!, deep_eq Symbol T_PAREN_OPEN
+        assert_that lexer\peek!, deep_eq Symbol T_PAREN_CLOSE
+        assert_that lexer\peek!, deep_eq Symbol T_PAREN_CLOSE
+        assert_that lexer\next!, deep_eq Symbol T_PAREN_CLOSE
 
       it 'returns nil at EOF', ->
         lexer = Lexer ''
@@ -236,17 +330,23 @@ spec ->
   describe 'Parser', ->
     describe 'run on simple types', ->
       it 'accepts primitives', ->
-        expect_that (type_checker 'nil'), anything!
-        expect_that (type_checker 'number'), anything!
-        expect_that (type_checker 'string'), anything!
-        expect_that (type_checker 'table'), anything!
-        expect_that (type_checker 'coroutine'), anything!
+        expect_that (parse 'nil'), deep_eq Primitive type nil
+        expect_that (parse 'number'), deep_eq Primitive type 0
+        expect_that (parse 'number'), deep_eq Primitive type 0.0
+        expect_that (parse 'string'), deep_eq Primitive type ""
+        expect_that (parse 'table'), deep_eq Primitive type {}
+        expect_that (parse 'function'), deep_eq Primitive type ->
+        expect_that (parse 'thread'), deep_eq Primitive type coroutine.create ->
 
       it 'accepts custom types', ->
-        expect_that (type_checker 'CustomType'), anything!
+        expect_that (parse 'CustomType'), deep_eq UserType 'CustomType'
 
       it 'rejects unknown primitives', ->
-        expect_that (-> type_checker, 'custom'), errors matches [[type 'custom' is not Lua primitive]]
+        expect_that (-> parse 'custom'), errors matches [[type 'custom' is not a Lua primitive]]
+
+    -- describe 'run on compositetypes', ->
+    --   it 'accepts lists', ->
+    --     expect_that (type_checker '[]')
 
   describe 'declare_type', ->
     it 'rejects false primitives', ->
@@ -269,7 +369,7 @@ spec ->
   --     expect_that (-> typed 'number', 123), no_errors!
 
 import set_log_verbosity from require 'fat.logger'
-set_log_verbosity true
-(require 'spec').run_tests 'declare_type rejects redefinition'
+-- set_log_verbosity true
+(require 'spec').run_tests select 1, ...
 
 -- print 'type checker:', type_checker 'boolean'

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -3,27 +3,23 @@ local Parser
 
 import spec, repr from require 'spec'
 
-type_checkers = {}
-
 export typed = (type_spec, value) ->
   if not type_spec?
     error 'cannot typecheck: no type spec provided'
 
-  checker = type_checkers[type_spec] ?? do
-    checker = type_checker type_spec
-    type_checkers[type_spec] = checker
-    checker
-  error 'todo'
-  -- checker_steps = type_checkers[type_spec] ?? do
-  --   program = generate_checker_program type_spec
-  --   type_checkers[type_spec] = program
-  --   program
-  -- checker = type_checker type_spec
-  -- print (require 'spec').repr checker
+  checker = type_checker type_spec
+  check checker, value
 
+type_checkers = {}
 type_checker = (type_spec) ->
-  parsed_type = parse type_spec
-  {} -- TODO(kcza): complete me!
+  type_checkers[type_spec] ?? do
+    -- Slow path: parse and generate checker
+    parsed_type = parse type_spec
+    checker = parsed_type\checker!
+
+    type_checkers[type_spec] = checker
+    print "got checker:\n#{repr checker}"
+    checker
 
 parse = (type_spec) ->
   type_spec_parser = TypeSpecParser Lexer type_spec
@@ -155,7 +151,7 @@ class TypeSpecParser extends Parser
         Mapping first_elem, maps_to
       when 'struct'
         @expect T_COLON
-        first_type = @parse_named_type!
+        first_type = @parse_type!
         first_field = Field first_elem, first_type
         if @lexer\peek!.type == T_COMMA
           @expect T_COMMA
@@ -296,6 +292,11 @@ class Primitive
 
   __tostring: => @name
 
+  checker: (prog={}) =>
+    with prog
+      [] = C_PRIMITIVE
+      [] = @name
+
 class UserType
   new: (@name) =>
 
@@ -314,6 +315,16 @@ class Tuple
     elem_type_reprs = [ tostring elem_type for elem_type in *@elem_types ]
     "(#{table.concat elem_type_reprs, ', '})"
 
+  checker: (prog={}) =>
+    with prog
+      [] = C_PRIMITIVE
+      [] = 'table'
+      for i = 1, #@elem_types
+        [] = C_PUSH
+        [] = i
+        @elem_types[i]\checker prog
+        [] = C_POP
+
 class Struct
   new: (@fields) =>
 
@@ -321,11 +332,24 @@ class Struct
     field_reprs = [ tostring field for field in *@fields ]
     "{#{table.concat field_reprs, ', '}}"
 
+  checker: (prog={}) =>
+    with prog
+      [] = C_PRIMITIVE
+      [] = 'table'
+      for field in *@fields
+        [] = C_PUSH
+        [] = field.name
+        field.type\checker prog
+        [] = C_POP
+
 class Field
   new: (@name, @type) =>
 
   __tostring: =>
     "#{@name}: #{@type}"
+
+  checker: (prog={}) =>
+    @type\checker prog
 
 class Set
   new: (@elem_type) =>
@@ -364,6 +388,32 @@ class Function
           first = false
           [] = tostring return_type
         [] = '>'
+
+C_PRIMITIVE = <tostring>: => 'PRIMITIVE'
+C_PUSH = <tostring>: => 'PUSH'
+C_POP = <tostring>: => 'POP'
+
+value_stack_size = 0
+value_stack = {}
+check = (check_prog, value) ->
+  value_stack_size = 1
+  value_stack[1] = value
+
+  for pc = 1, #check_prog
+    switch check_prog[pc]
+      when C_PRIMITIVE
+        ty = type value_stack[value_stack_size]
+        pc += 1
+        if ty != check_prog[pc]
+          error "incorrect type: expected #{check_prog[pc]} but got #{ty}"
+      when C_PUSH
+        pc += 1
+        field = value_stack[value_stack_size][check_prog[pc]]
+        value_stack_size += 1
+        value_stack[value_stack_size] = field
+      when C_POP
+        value_stack[value_stack_size] = nil
+        value_stack_size -= 1
 
 export declare_type = (name, type_spec) ->
   if not (name\sub 1, 1)\match '^[A-Z_]$'
@@ -485,27 +535,58 @@ spec ->
         expect_that (parse '{field1: number, field2: string}'), deep_eq Struct
           * Field 'field1', Primitive 'number'
           * Field 'field2', Primitive 'string'
+        expect_that (parse '{outer1: {inner1: boolean}, outer2: {inner2: boolean}}'), deep_eq Struct
+          * Field 'outer1', Struct
+            * Field 'inner1', Primitive 'boolean'
+          * Field 'outer2', Struct
+            * Field 'inner2', Primitive 'boolean'
 
   describe 'declare_type', ->
     it 'rejects false primitives', ->
       expect_that (-> declare_type 'custom'), errors matches 'custom types must start with uppercase'
 
-    it 'rejects redefinition', ->
-      declare_type 'Custom', 'number'
-      expect_that (-> declare_type 'Custom'), errors matches [[cannot redefine type 'Custom']]
+    -- it 'rejects redefinition', ->
+    --   declare_type 'Custom', 'number'
+    --   expect_that (-> declare_type 'Custom'), errors matches [[cannot redefine type 'Custom']]
 
-  -- describe 'typed', ->
-  --   it 'requires two arguments', ->
-  --     expect_that (-> typed!), errors matches 'cannot typecheck: no type spec provided'
-  --   --
-  --   -- it 'handles nils', ->
-  --   --   expect_that (-> typed 'nil', nil), no_errors!
-  --   --   expect_that (-> typed 'nil', 123), errors anything!
-  --
-  --   it 'handles numbers', ->
-  --     expect_that (-> typed 'number', nil), errors anything!
-  --     expect_that (-> typed 'number', 123), no_errors!
+  describe 'typed', ->
+    it 'requires two arguments', ->
+      expect_that (-> typed!), errors matches 'cannot typecheck: no type spec provided'
+
+    it 'checks primitive types', ->
+      expect_that (-> typed 'nil', nil), no_errors!
+      expect_that (-> typed 'number', 123), no_errors!
+      expect_that (-> typed 'string', 'some-string'), no_errors!
+
+      expect_that (-> typed 'nil', 123), errors matches 'incorrect type: expected nil but got number'
+      expect_that (-> typed 'number', nil), errors matches 'incorrect type: expected number but got nil'
+      expect_that (-> typed 'string', 123), errors matches 'incorrect type: expected string but got number'
+
+    it 'checks tuples', ->
+      expect_that (-> typed '(number, boolean, string)', {123, true, 'hello'}), no_errors!
+      expect_that (-> typed '(number, boolean, string)', {123, true, 'hello', coroutine.create ->}), no_errors!
+      expect_that (-> typed '((number, boolean), (string, thread))', {{123, true}, {'hello', coroutine.create ->}}), no_errors!
+
+      expect_that (-> typed '(number, boolean, string)', nil), errors matches 'incorrect type: expected table but got nil'
+      expect_that (-> typed '(number, boolean, string)', {}), errors matches 'incorrect type: expected number but got nil'
+      expect_that (-> typed '(number, boolean, string)', {123}), errors matches 'incorrect type: expected boolean but got nil'
+      expect_that (-> typed '(number, boolean, string)', {'interloper'}), errors matches 'incorrect type: expected number but got string'
+
+    it 'checks structs', ->
+      expect_that (-> typed '{}', {}), no_errors!
+      expect_that (-> typed '{}', {123}), no_errors!
+      expect_that (-> typed '{}', {hello: 123}), no_errors!
+      expect_that (-> typed '{hello: string}', {hello: 'hello'}), no_errors!
+      expect_that (-> typed '{hello: {world: string}}', {hello: world: 'world'}), no_errors!
+
+      expect_that (-> typed '{}', 132), errors matches 'incorrect type: expected table but got number'
+      expect_that (-> typed '{hello: string}', {}), errors matches 'incorrect type: expected string but got nil'
+      expect_that (-> typed '{hello: string}', hello: 123), errors matches 'incorrect type: expected string but got number'
+      expect_that (-> typed '{hello: {world: string}}', hello: 123), errors matches 'incorrect type: expected table but got number'
+      expect_that (-> typed '{hello: {world: string}}', hello: {}), errors matches 'incorrect type: expected string but got nil'
+      expect_that (-> typed '{hello: {world: string}}', hello: world: 123), errors matches 'incorrect type: expected string but got number'
 
 -- import set_log_verbosity from require 'fat.logger'
 -- set_log_verbosity true
 (require 'spec').run_tests select 1, ...
+-- TODO(kcza): optional values

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -778,6 +778,7 @@ spec ->
       expect_that (-> T '{number -> string}', {'hello', [10]: 'world'}), no_errors!
       expect_that (-> T '{{boolean -> number} -> {string -> thread}}', {[{[true]: 123}]: {asdf: coroutine.create ->}}), no_errors!
 
+      expect_that (-> T '{number -> string}', nil), errors matches 'incorrect type: expected table but got nil'
       expect_that (-> T '{number -> string}', {123}), errors matches 'incorrect type: expected string but got number'
       expect_that (-> T '{number -> string}', {'hello', 'world', 'foo', 'bar', 'baz', 123}), errors matches 'incorrect type: expected string but got number'
 

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -102,7 +102,7 @@ class TypeSpecParser extends Parser
       * token: T_NAME
         action: @\parse_named_type
       * token: T_BRACKET_OPEN
-        action: @\parse_list
+        action: @\parse_array
       * token: T_PAREN_OPEN
         action: @\parse_tuple_or_function
       * token: T_BRACE_OPEN
@@ -111,12 +111,12 @@ class TypeSpecParser extends Parser
   parse_named_type: =>
     named_type @expect T_NAME
 
-  parse_list: =>
+  parse_array: =>
     {_, elem_type, _} = @sequence
       * token: T_BRACKET_OPEN
       * action: @\parse_type
       * token: T_BRACKET_CLOSE
-    List elem_type
+    Array elem_type
 
   parse_tuple_or_function: =>
     @expect T_PAREN_OPEN
@@ -346,7 +346,7 @@ class Optional
 
       [label_placeholder_index] = #prog + 1
 
-class List
+class Array
   new: (@elem_type) =>
 
   __tostring: =>
@@ -374,7 +374,7 @@ class List
       [loop_exit_jump_index] = #prog + 1
       [] = C_POP
       [] = C_ASSERT_LEN
-      [] = C_POP -- TODO(kcza): check stack on early exit
+      [] = C_POP
 
 class Tuple
   new: (@elem_types) =>
@@ -518,7 +518,7 @@ check = (check_prog, value) ->
           len = #value_stack[value_stack_size-1]
           first_nil_index = value_stack[value_stack_size]
           if len != first_nil_index-1
-            error "incorrect type: expected List but got table"
+            error "incorrect type: expected array but got table"
         when C_GET_FIELD
           value_stack_size += 1
           value_stack[value_stack_size] = value_stack[value_stack_size-2][value_stack[value_stack_size-1]]
@@ -633,9 +633,9 @@ spec ->
         expect_that (parse '?string'), deep_eq Optional Primitive 'string'
         expect_that (parse '?() -> nil'), deep_eq Optional Function {}, {}
 
-      it 'accepts lists', ->
-        expect_that (parse '[string]'), deep_eq List Primitive 'string'
-        expect_that (parse '[[string]]'), deep_eq List List Primitive 'string'
+      it 'accepts arrays', ->
+        expect_that (parse '[string]'), deep_eq Array Primitive 'string'
+        expect_that (parse '[[string]]'), deep_eq Array Array Primitive 'string'
 
       it 'accepts tuples', ->
         expect_that (parse '()'), deep_eq Tuple {}
@@ -699,7 +699,7 @@ spec ->
       expect_that (-> T '?number', 'str'), errors matches 'incorrect type: expected number but got string'
       expect_that (-> T '?(number)', 'str'), errors matches 'incorrect type: expected table but got string'
 
-    it 'checks lists', ->
+    it 'checks arrays', ->
       expect_that (-> T '[number]', {}), no_errors!
       expect_that (-> T '[number]', {123, 312}), no_errors!
       expect_that (-> T '[[number]]', {{123}, {312}}), no_errors!

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -280,7 +280,6 @@ spec ->
         * type ""
         * type ->
         * type coroutine.create ->
-        * type coroutine.wrap ->
       for simple_type in *simple_types
         expect_that (tokens simple_type), deep_eq {
           Symbol T_NAME, Primitive simple_type

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -517,16 +517,16 @@ validate = (check_prog) ->
     if instruction == LABEL_PLACEHOLDER
       error "unresolved placeholder in check program:\n#{repr check_prog}"
 
-value_stack_size = 0
-value_stack = {}
+stack_size = 0
+stack = {}
 check_error = (...) ->
-  for i = 1, value_stack_size
-    value_stack[i] = nil
-  value_stack_size = 0
+  for i = 1, stack_size
+    stack[i] = nil
+  stack_size = 0
   error ...
 check = (check_prog, value) ->
-  value_stack_size = 1
-  value_stack[1] = value
+  stack_size = 1
+  stack[1] = value
 
   with check_prog
     local pc = 0
@@ -534,54 +534,54 @@ check = (check_prog, value) ->
     while pc < n_instructions
       pc += 1
       if DEBUG
-        print "stack state #{[pc]}@#{pc} [#{value_stack_size}]:\n\t#{table.concat [ "#{i}:\t#{repr value_stack[i]}" for i = 1, value_stack_size], '\n\t'}"
+        print "stack state #{[pc]}@#{pc} [#{stack_size}]:\n\t#{table.concat [ "#{i}:\t#{repr stack[i]}" for i = 1, stack_size], '\n\t'}"
       switch [pc]
         when C_PUSH
           pc += 1
           value = [pc]
           if value == V_NIL
             value = nil
-          value_stack_size += 1
-          value_stack[value_stack_size] = value
+          stack_size += 1
+          stack[stack_size] = value
         when C_POP
-          value_stack[value_stack_size] = nil
-          value_stack_size -= 1
+          stack[stack_size] = nil
+          stack_size -= 1
         when C_ASSERT_PRIMITIVE
-          ty = type value_stack[value_stack_size]
+          ty = type stack[stack_size]
           pc += 1
           if ty != [pc]
             check_error "incorrect type: expected #{check_prog[pc]} but got #{ty}"
         when C_ASSERT_LEN
-          len = #value_stack[value_stack_size-1]
-          first_nil_index = value_stack[value_stack_size]
+          len = #stack[stack_size-1]
+          first_nil_index = stack[stack_size]
           if len != first_nil_index-1
             check_error "incorrect type: expected array but got table"
         when C_GET_FIELD
-          value_stack_size += 1
-          value_stack[value_stack_size] = value_stack[value_stack_size-2][value_stack[value_stack_size-1]]
+          stack_size += 1
+          stack[stack_size] = stack[stack_size-2][stack[stack_size-1]]
         when C_INCR
-          value_stack[value_stack_size] += 1
+          stack[stack_size] += 1
         when C_NEXT
-          tab = value_stack[value_stack_size-1]
-          idx = value_stack[value_stack_size]
+          tab = stack[stack_size-1]
+          idx = stack[stack_size]
           next_idx, value = next tab, idx
-          value_stack[value_stack_size] = next_idx
-          value_stack_size += 1
-          value_stack[value_stack_size] = value
+          stack[stack_size] = next_idx
+          stack_size += 1
+          stack[stack_size] = value
         when C_JMP
           pc = [pc + 1] - 1
         when C_JMP_IF_NIL
-          if value_stack[value_stack_size]?
+          if stack[stack_size]?
             pc += 1
           else
             pc = [pc + 1] - 1
         else
           check_error "internal error: illegal type-checker VM instruction #{[pc]}@#{pc}"
   if true -- DEBUG
-    print "FINAL stack state #{check_prog[pc]}@#{pc} [#{value_stack_size}]:\n\t#{table.concat [ "#{i}:\t#{repr value_stack[i]}" for i = 1, value_stack_size], '\n\t'}"
-  assert value_stack_size == 1, "internal error: value stack is not 1"
-  value_stack[1] = nil
-  value_stack_size = 0
+    print "FINAL stack state #{check_prog[pc]}@#{pc} [#{stack_size}]:\n\t#{table.concat [ "#{i}:\t#{repr stack[i]}" for i = 1, stack_size], '\n\t'}"
+  assert stack_size == 1, "internal error: value stack is not 1"
+  stack[1] = nil
+  stack_size = 0
 
 export declare_type = (name, type_spec) ->
   if not (name\sub 1, 1)\match '^[A-Z_]$'

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -11,6 +11,7 @@ export T = (type_spec, value) ->
   check checker, value
 
 DEBUG = false
+COLLECT_STATS = false
 
 type_checkers = {}
 type_checker = (type_spec) ->
@@ -546,6 +547,7 @@ check_error = (...) ->
     stack[i] = nil
   stack_size = 0
   error ...
+instruction_counts = {}
 check = (check_prog, value) ->
   stack_size = 1
   stack[1] = value
@@ -555,6 +557,11 @@ check = (check_prog, value) ->
     n_instructions = #check_prog
     while pc < n_instructions
       pc += 1
+      if COLLECT_STATS
+        instruction_counts[ [pc] ] = if v = instruction_counts[ [pc] ]
+          v + 1
+        else
+          1
       if DEBUG
         print "stack state #{[pc]}@#{pc} [#{stack_size}]:\n\t#{table.concat [ "#{i}:\t#{repr stack[i]}" for i = 1, stack_size], '\n\t'}"
       switch [pc]
@@ -618,9 +625,14 @@ export declare_type = (name, type_spec) ->
 export deactivate = ->
   T = (_, fn) -> fn
 
+export stats = ->
+  stats_arr = [:instruction, :count for instruction, count in pairs instruction_counts]
+  table.sort stats_arr, (a, b) -> a.count > b.count
+  stats_arr
+
 spec ->
   import assert_that, expect_that, describe, it, matchers from require 'spec'
-  import anything, contains_value, deep_eq, eq, errors, fields, len, match, matches, no_errors from matchers
+  import anything, contains_value, deep_eq, each_value, eq, errors, fields, ge, gt, len, match, matches, no_errors from matchers
 
   describe 'Lexer', ->
     tokens = (raw) ->
@@ -836,7 +848,19 @@ spec ->
       expect_that (-> T '() -> nil', ->), no_errors!
       expect_that (-> T '() -> nil', {}), errors matches 'incorrect type: expected function but got table'
 
+  describe 'stats', ->
+    it 'has the correct type', ->
+      prev_collect_stats = COLLECT_STATS
+      COLLECT_STATS = true
+
+      T 'string', 'hello' -- Exercise the checker
+      stats_arr = stats!
+      expect_that stats_arr, len gt 0
+      expect_that stats_arr, each_value fields count: ge 0
+
+      COLLECT_STATS = prev_collect_stats
+
 -- import set_log_verbosity from require 'fat.logger'
 -- set_log_verbosity true
-DEBUG = true
+-- DEBUG = true
 (require 'spec').run_tests select 1, ...

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -100,7 +100,7 @@ class TypeSpecParser extends Parser
       * token: T_BRACKET_OPEN
         action: @\parse_list
       * token: T_PAREN_OPEN
-        action: @\parse_tuple
+        action: @\parse_tuple_or_function
       * token: T_BRACE_OPEN
         action: @\parse_table
 
@@ -116,12 +116,20 @@ class TypeSpecParser extends Parser
 
   parse_tuple_or_function: =>
     @expect T_PAREN_OPEN
+    local types
     if @maybe T_PAREN_CLOSE
-      return Tuple {}
-    {types, _} = @sequence
-      * action: -> @parse_repeat_separated @\parse_type, T_COMMA
-      * token: T_PAREN_CLOSE
-    Tuple types
+      types = {}
+    else
+      {types, _} = @sequence
+        * action: -> @parse_repeat_separated @\parse_type, T_COMMA
+        * token: T_PAREN_CLOSE
+    if not @maybe T_ARROW
+      return Tuple types
+
+    return_type = @parse_type!
+    if return_type.name? and return_type.name == 'nil'
+      return_type = nil
+    Function types, {return_type}
 
   parse_table: =>
     {_, table, _} = @sequence
@@ -437,7 +445,9 @@ class Function
         [] = '>'
 
   checker: (prog={}) =>
-    error 'todo'
+    with prog
+      [] = C_ASSERT_PRIMITIVE
+      [] = 'function'
 
 C_PUSH = <tostring>: => '<push>'
 C_POP = <tostring>: => '<pop>'
@@ -608,6 +618,11 @@ spec ->
           * Field 'outer2', Struct
             * Field 'inner2', Primitive 'boolean'
 
+      it 'accepts functions', ->
+        expect_that (parse '() -> nil'), deep_eq Function {}, {}
+        expect_that (parse '(string) -> number'), deep_eq Function {Primitive 'string'}, {Primitive 'number'}
+        expect_that (parse '(string) -> (number) -> boolean'), deep_eq Function {Primitive 'string'}, {Function {Primitive 'number'}, {Primitive 'boolean'}}
+
   describe 'declare_type', ->
     it 'rejects false primitives', ->
       expect_that (-> declare_type 'custom'), errors matches 'custom types must start with uppercase'
@@ -655,6 +670,10 @@ spec ->
       expect_that (-> typed '{hello: {world: string}}', hello: {}), errors matches 'incorrect type: expected string but got nil'
       expect_that (-> typed '{hello: {world: string}}', hello: world: 123), errors matches 'incorrect type: expected string but got number'
       expect_that (-> typed '{hello: {world: string}, foo: boolean}', hello: {world:'asdf'}, foo: 123), errors matches 'incorrect type: expected boolean but got number'
+
+    it 'checks functions', ->
+      expect_that (-> typed '() -> nil', ->), no_errors!
+      expect_that (-> typed '() -> nil', {}), errors matches 'incorrect type: expected function but got table'
 
 -- import set_log_verbosity from require 'fat.logger'
 -- set_log_verbosity true

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -434,7 +434,28 @@ class Set
     "{#{@elem_type}}"
 
   checker: (prog={}) =>
-    error 'todo'
+    with prog
+      [] = C_ASSERT_PRIMITIVE
+      [] = 'table'
+      [] = C_PUSH
+      [] = V_NIL
+      [] = C_NEXT
+
+      loop_start = #prog + 1
+      [] = C_JMP_IF_NIL
+      loop_exit_jump_index = #prog + 1
+      [] = LABEL_PLACEHOLDER
+      [] = C_ASSERT_TRUTHY
+      [] = C_POP
+      @elem_type\checker prog
+
+      [] = C_NEXT
+      [] = C_JMP
+      [] = loop_start
+
+      [loop_exit_jump_index] = #prog + 1
+      [] = C_POP
+      [] = C_POP
 
 class Mapping
   new: (@in_type, @out_type) =>
@@ -502,6 +523,7 @@ class Function
 C_PUSH = <tostring>: => '<push>'
 C_POP = <tostring>: => '<pop>'
 C_ASSERT_PRIMITIVE = <tostring>: => '<assert-primitive>'
+C_ASSERT_TRUTHY = <tostring>: => '<assert-truthy>'
 C_ASSERT_LEN = <tostring>: => '<assert-len>'
 C_GET_FIELD = <tostring>: => '<field>'
 C_INCR = <tostring>: => '<incr>'
@@ -551,6 +573,9 @@ check = (check_prog, value) ->
           pc += 1
           if ty != [pc]
             check_error "incorrect type: expected #{check_prog[pc]} but got #{ty}"
+        when C_ASSERT_TRUTHY
+          if not stack[stack_size]
+            check_error "incorrect type: expected a truthy value but got #{stack[stack_size]}"
         when C_ASSERT_LEN
           len = #stack[stack_size-1]
           first_nil_index = stack[stack_size]
@@ -772,6 +797,15 @@ spec ->
       expect_that (-> T '(number, boolean, string)', {}), errors matches 'incorrect type: expected number but got nil'
       expect_that (-> T '(number, boolean, string)', {123}), errors matches 'incorrect type: expected boolean but got nil'
       expect_that (-> T '(number, boolean, string)', {'interloper'}), errors matches 'incorrect type: expected number but got string'
+
+    it 'checks sets', ->
+      expect_that (-> T '{number}', {}), no_errors!
+      expect_that (-> T '{number}', {[123]: true, [321]: {}}), no_errors!
+      expect_that (-> T '{{number}}', {[{123}]: true}), no_errors!
+
+      expect_that (-> T '{number}', nil), errors matches 'incorrect type: expected table but got nil'
+      expect_that (-> T '{number}', {[123]: false}), errors matches 'incorrect type: expected a truthy value but got false'
+      expect_that (-> T '{{number}}', {[{['asdf']: true}]: true}), errors matches 'incorrect type: expected number but got string'
 
     it 'checks mappings', ->
       expect_that (-> T '{string -> number}', {}), no_errors!

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -1379,7 +1379,7 @@ spec ->
 
     it 'accepts remainder return values', ->
       expect_that (-> (F '() -> string...', ->)!), no_errors!
-      expect_that (-> (F '() -> string...', ->, 'hello', 'world')!), no_errors!
+      expect_that (-> (F '() -> string...', -> 'hello', 'world')!), no_errors!
       expect_that (-> (F '() -> <number, string...>', -> 123, 'hello', 'world')!), no_errors!
 
       expect_that (-> (F '() -> <number, string...>', -> 123, 'hello', true)!), errors matches 'incorrect type: expected string but got boolean'

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -179,10 +179,27 @@ class TypeSpecParser extends Parser
     if not @maybe T_ARROW
       return Tuple types
 
-    return_type = @parse_type!
-    if return_type.name? and return_type.name == 'nil'
-      return_type = nil
-    Function types, {return_type}
+    Function types, @parse_return_type!
+
+  parse_return_type: =>
+    @select
+      * token: T_NAME
+        action: ->
+          ty = @parse_named_type!
+          if ty.name == 'nil'
+            {} -- 'nil' is an alternative spelling of '<>'
+          else
+            { ty }
+      * token: T_ANGLE_OPEN
+        action: ->
+          @expect T_ANGLE_OPEN
+          if @maybe  T_ANGLE_CLOSE
+            return {}
+          types = @parse_repeat_separated @\parse_type, T_COMMA
+          @expect T_ANGLE_CLOSE
+          types
+      otherwise: ->
+        { @parse_type! }
 
   parse_table: =>
     {_, table, _} = @sequence
@@ -253,6 +270,8 @@ T_BRACE_OPEN = <tostring>: => "'{'"
 T_BRACE_CLOSE = <tostring>: => "'}'"
 T_BRACKET_OPEN = <tostring>: => "'['"
 T_BRACKET_CLOSE = <tostring>: => "']'"
+T_ANGLE_OPEN = <tostring>: => '"<"'
+T_ANGLE_CLOSE = <tostring>: => '">"'
 T_COMMA = <tostring>: => "','"
 T_COLON = <tostring>: => "':'"
 T_ARROW = <tostring>: => "'->'"
@@ -287,6 +306,10 @@ class Lexer
           T_COLON, nil, #match
         else if match = type_spec\match '^->', @index
           T_ARROW, nil, #match
+        else if match = type_spec\match '^<', @index
+          T_ANGLE_OPEN, nil, #match
+        else if match = type_spec\match '^>', @index
+          T_ANGLE_CLOSE, nil, #match
         else if match = type_spec\match '^?', @index
           T_QUESTION, nil, #match
         else if name = type_spec\match '^([a-zA-Z_][a-zA-Z0-9_]*)', @index
@@ -930,8 +953,12 @@ spec ->
 
       it 'accepts functions', ->
         expect_that (parse '() -> nil'), deep_eq Function {}, {}
+        expect_that (parse '() -> <>'), deep_eq Function {}, {}
         expect_that (parse '(string) -> number'), deep_eq Function {Primitive 'string'}, {Primitive 'number'}
+        expect_that (parse '(number, string) -> number'), deep_eq Function {(Primitive 'number'), (Primitive 'string')}, {Primitive 'number'}
         expect_that (parse '(string) -> (number) -> boolean'), deep_eq Function {Primitive 'string'}, {Function {Primitive 'number'}, {Primitive 'boolean'}}
+        expect_that (parse '() -> <string>'), deep_eq Function {}, {(Primitive 'string')}
+        expect_that (parse '() -> <string, boolean>'), deep_eq Function {}, {(Primitive 'string'), (Primitive 'boolean')}
 
   describe 'T', ->
     it 'requires two arguments', ->
@@ -1071,6 +1098,9 @@ spec ->
     it 'accepts absent optional retunsr', ->
       expect_that (-> (F '() -> nil', ->)!), no_errors!
 
+    it 'accepts multiple return values', ->
+      expect_that (-> (F '() -> <string, boolean>', -> 'a', true)!), no_errors!
+
     it 'rejects non-function types', ->
       expect_that (-> F '{}', ->), errors matches 'cannot typecheck: expected a function type'
 
@@ -1085,6 +1115,10 @@ spec ->
 
     it 'rejects extra return arguments', ->
       expect_that (-> (F '() -> string', -> 'a', 'b')!), errors matches 'function returned too many values'
+
+    it 'rejects multiple incorrect return values', ->
+      expect_that (-> (F '() -> <string, boolean>', -> {}, true)!), errors matches 'incorrect type: expected string but got table'
+      expect_that (-> (F '() -> <string, boolean>', -> 'asdf', {})!), errors matches 'incorrect type: expected boolean but got table'
 
   describe 'stats', ->
     it 'has the correct type', ->

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -56,7 +56,7 @@ class Lexer
     @tokens = coroutine.wrap ->
       original_type_spec = type_spec
       while #type_spec > 0
-        token_type, token = if whitespace = type_spec\match '^[ \t\r\n]'
+        token_type, token_value = if whitespace = type_spec\match '^[ \t\r\n]'
           nil, whitespace
         else if type_spec\match '^%('
           PAREN_OPEN, '('
@@ -79,9 +79,9 @@ class Lexer
         else
           error "unrecognised character '#{type_spec\sub 1, 1}' in type spec '#{original_type_spec}"
 
-        type_spec = type_spec\sub #token + 1
+        type_spec = type_spec\sub #token_value + 1
         if token_type?
-          coroutine.yield token_type, token
+          coroutine.yield { :token_type, :token_value }
 
   peek: =>
     if @done
@@ -90,10 +90,10 @@ class Lexer
     if @peeked?
       return @peeked
 
-    @peeked = {@tokens!}
+    @peeked = @tokens!
     if not @peeked
       @done = true
-    unpack @peeked
+    @peeked
 
   next: =>
     if @done
@@ -102,7 +102,7 @@ class Lexer
     if @peeked?
       peeked = @peeked
       @peeked = nil
-      unpack peeked
+      peeked
     else
       @tokens!
 
@@ -110,14 +110,14 @@ declare_type = (name, type_spec) ->
   error 'todo'
 
 spec ->
-  import expect_that, describe, it, matchers from require 'spec'
+  import assert_that, expect_that, describe, it, matchers from require 'spec'
   import anything, deep_eq, eq, errors, match, matches, no_errors from matchers
 
   describe 'lex', ->
     tokens = (raw) ->
       with {}
-        for token_type, token in (Lexer raw).tokens
-          [] = { :token_type, :token }
+        for token in (Lexer raw).tokens
+          [] = token
 
     it 'emits simple types', ->
       simple_types =
@@ -127,28 +127,28 @@ spec ->
         * type ""
       for simple_type in *simple_types
         expect_that (tokens simple_type), deep_eq {
-          { token_type: NAME, token: simple_type },
+          { token_type: NAME, token_value: simple_type },
         }
 
     it 'emits strucural tokens', ->
       expect_that (tokens '(),{}[]->'), deep_eq {
-        { token_type: PAREN_OPEN, token: '(' },
-        { token_type: PAREN_CLOSE, token: ')' },
-        { token_type: COMMA, token: ',' },
-        { token_type: BRACE_OPEN, token: '{' },
-        { token_type: BRACE_CLOSE, token: '}' },
-        { token_type: BRACKET_OPEN, token: '[' },
-        { token_type: BRACKET_CLOSE, token: ']' },
-        { token_type: ARROW, token: '->' },
+        { token_type: PAREN_OPEN, token_value: '(' },
+        { token_type: PAREN_CLOSE, token_value: ')' },
+        { token_type: COMMA, token_value: ',' },
+        { token_type: BRACE_OPEN, token_value: '{' },
+        { token_type: BRACE_CLOSE, token_value: '}' },
+        { token_type: BRACKET_OPEN, token_value: '[' },
+        { token_type: BRACKET_CLOSE, token_value: ']' },
+        { token_type: ARROW, token_value: '->' },
       }
 
     it 'ignores whitespace', ->
       expect_that (tokens ' (\tstring\r)\n-> string '), deep_eq {
-        { token_type: PAREN_OPEN, token: "(" },
-        { token_type: NAME, token: "string" },
-        { token_type: PAREN_CLOSE, token: ")" },
-        { token_type: ARROW, token: "->" },
-        { token_type: NAME, token: "string" },
+        { token_type: PAREN_OPEN, token_value: "(" },
+        { token_type: NAME, token_value: "string" },
+        { token_type: PAREN_CLOSE, token_value: ")" },
+        { token_type: ARROW, token_value: "->" },
+        { token_type: NAME, token_value: "string" },
       }
 
     it 'rejects unrecognised characters', ->
@@ -158,14 +158,17 @@ spec ->
     describe ':peek', ->
       it 'matches :next', ->
         lexer = Lexer '()'
-        expect_that {lexer\peek!}, deep_eq {PAREN_OPEN, '('}
-        expect_that {lexer\next!}, deep_eq {PAREN_OPEN, '('}
-        expect_that {lexer\peek!}, deep_eq {PAREN_OPEN, ')'}
-        expect_that {lexer\next!}, deep_eq {PAREN_OPEN, ')'}
+        assert_that lexer\peek!, deep_eq { token_type: PAREN_OPEN, token_value: '('}
+        assert_that lexer\peek!, deep_eq { token_type: PAREN_OPEN, token_value: '('}
+        assert_that lexer\next!, deep_eq { token_type: PAREN_OPEN, token_value: '('}
+        assert_that lexer\peek!, deep_eq { token_type: PAREN_CLOSE, token_value: ')'}
+        assert_that lexer\peek!, deep_eq { token_type: PAREN_CLOSE, token_value: ')'}
+        assert_that lexer\next!, deep_eq { token_type: PAREN_CLOSE, token_value: ')'}
 
       it 'returns nil on empty peek', ->
         lexer = Lexer ''
-        expect_that {lexer\peek!}, deep_eq {}
+        expect_that lexer\peek!, eq nil
+        expect_that lexer\peek!, eq nil
 
   -- describe 'typed', ->
   --   it 'requires two arguments', ->
@@ -181,4 +184,4 @@ spec ->
 
 (require 'spec').run_tests!
 
-type_checker '(string, string) -> boolean'
+-- type_checker '(string, string) -> boolean'

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -1,4 +1,5 @@
 local *
+local Parser
 
 import spec, repr from require 'spec'
 
@@ -20,58 +21,18 @@ export typed = (type_spec, value) ->
   -- checker = type_checker type_spec
   -- print (require 'spec').repr checker
 
--- Tokens
-T_PAREN_OPEN = <tostring>: => "<paren_open>"
-T_PAREN_CLOSE = <tostring>: => "<paren_close>"
-T_BRACE_OPEN = <tostring>: => "<brace_open>"
-T_BRACE_CLOSE = <tostring>: => "<brace_close>"
-T_BRACKET_OPEN = <tostring>: => "<bracket_open>"
-T_BRACKET_CLOSE = <tostring>: => "<bracket_close>"
-T_COMMA = <tostring>: => "<comma>"
-T_ARROW = <tostring>: => "<arrow>"
-T_NAME = <tostring>: => "<name>"
-
 type_checker = (type_spec) ->
   parsed_type = parse type_spec
   {} -- TODO(kcza): complete me!
 
 parse = (type_spec) ->
-  type_spec_parser = Parser Lexer type_spec
+  type_spec_parser = TypeSpecParser Lexer type_spec
   type_spec_parser\parse!
 
 class Parser
   new: (@lexer) =>
-
   parse: =>
-    @parse_type!
-
-  parse_type: =>
-    @select
-      * token: T_NAME
-        action: @\parse_name
-      * token: T_BRACKET_OPEN
-        action: @\parse_list
-      * token: T_PAREN_OPEN
-        action: @\parse_tuple
-
-  parse_name: =>
-    name_token = @lexer\next!
-    assert T_NAME == name_token.type
-    name_token.value
-
-  parse_list: =>
-    {_, elem_type, _} = @sequence
-      * token: T_BRACKET_OPEN
-      * action: @\parse_type
-      * token: T_BRACKET_CLOSE
-    List elem_type
-
-  parse_tuple: =>
-    {_, elem_types, _} = @sequence
-      * token: T_PAREN_OPEN
-      * action: -> @parse_repeat_separated @\parse_type, T_COMMA
-      * token: T_PAREN_CLOSE
-    Tuple elem_types
+    error 'unimplemented'
 
   parse_repeat_separated: (elem_parser, sep_token) =>
     with {}
@@ -108,6 +69,49 @@ class Parser
           [] = token.value ?? 0
         else if action?
           [] = action!
+
+class TypeSpecParser extends Parser
+  parse: =>
+    @parse_type!
+
+  parse_type: =>
+    @select
+      * token: T_NAME
+        action: @\parse_name
+      * token: T_BRACKET_OPEN
+        action: @\parse_list
+      * token: T_PAREN_OPEN
+        action: @\parse_tuple
+
+  parse_name: =>
+    name_token = @lexer\next!
+    assert T_NAME == name_token.type
+    name_token.value
+
+  parse_list: =>
+    {_, elem_type, _} = @sequence
+      * token: T_BRACKET_OPEN
+      * action: @\parse_type
+      * token: T_BRACKET_CLOSE
+    List elem_type
+
+  parse_tuple: =>
+    {_, elem_types, _} = @sequence
+      * token: T_PAREN_OPEN
+      * action: -> @parse_repeat_separated @\parse_type, T_COMMA
+      * token: T_PAREN_CLOSE
+    Tuple elem_types
+
+-- Tokens
+T_PAREN_OPEN = <tostring>: => "<paren_open>"
+T_PAREN_CLOSE = <tostring>: => "<paren_close>"
+T_BRACE_OPEN = <tostring>: => "<brace_open>"
+T_BRACE_CLOSE = <tostring>: => "<brace_close>"
+T_BRACKET_OPEN = <tostring>: => "<bracket_open>"
+T_BRACKET_CLOSE = <tostring>: => "<bracket_close>"
+T_COMMA = <tostring>: => "<comma>"
+T_ARROW = <tostring>: => "<arrow>"
+T_NAME = <tostring>: => "<name>"
 
 class Lexer
   new: (type_spec) =>

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -90,7 +90,6 @@ class Parser
           error "sequence element must have expected_token or action"
 
 class TypeSpecParser extends Parser
-
   parse: =>
     @parse_type!
 

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -1021,6 +1021,7 @@ spec ->
 
     it 'checks functions', ->
       expect_that (-> T '() -> nil', ->), no_errors!
+      expect_that (-> T '() -> nil', -> nil), no_errors!
       expect_that (-> T '() -> nil', {}), errors matches 'incorrect type: expected function but got table'
 
   describe 'declare_type', ->

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -3,7 +3,7 @@ local Parser
 
 import spec, repr from require 'spec'
 
-export typed = (type_spec, value) ->
+export t = (type_spec, value) ->
   if not type_spec?
     error 'cannot typecheck: no type spec provided'
 
@@ -506,7 +506,7 @@ export declare_type = (name, type_spec) ->
   type_checkers[name] = type_checker name
 
 export deactivate = ->
-  typed = (_, fn) -> fn
+  t = (_, fn) -> fn
 
 spec ->
   import assert_that, expect_that, describe, it, matchers from require 'spec'
@@ -638,49 +638,49 @@ spec ->
     --   declare_type 'Custom', 'number'
     --   expect_that (-> declare_type 'Custom'), errors matches [[cannot redefine type 'Custom']]
 
-  describe 'typed', ->
+  describe 't', ->
     it 'requires two arguments', ->
-      expect_that (-> typed!), errors matches 'cannot typecheck: no type spec provided'
+      expect_that (-> t!), errors matches 'cannot typecheck: no type spec provided'
 
     it 'checks primitive types', ->
-      expect_that (-> typed 'nil', nil), no_errors!
-      expect_that (-> typed 'number', 123), no_errors!
-      expect_that (-> typed 'string', 'some-string'), no_errors!
+      expect_that (-> t 'nil', nil), no_errors!
+      expect_that (-> t 'number', 123), no_errors!
+      expect_that (-> t 'string', 'some-string'), no_errors!
 
-      expect_that (-> typed 'nil', 123), errors matches 'incorrect type: expected nil but got number'
-      expect_that (-> typed 'number', nil), errors matches 'incorrect type: expected number but got nil'
-      expect_that (-> typed 'string', 123), errors matches 'incorrect type: expected string but got number'
+      expect_that (-> t 'nil', 123), errors matches 'incorrect type: expected nil but got number'
+      expect_that (-> t 'number', nil), errors matches 'incorrect type: expected number but got nil'
+      expect_that (-> t 'string', 123), errors matches 'incorrect type: expected string but got number'
 
     it 'checks tuples', ->
-      expect_that (-> typed '()', {}), no_errors!
-      expect_that (-> typed '(number, boolean, string)', {123, true, 'hello'}), no_errors!
-      expect_that (-> typed '(number, boolean, string)', {123, true, 'hello', coroutine.create ->}), no_errors!
-      expect_that (-> typed '((number, boolean), (string, thread))', {{123, true}, {'hello', coroutine.create ->}}), no_errors!
+      expect_that (-> t '()', {}), no_errors!
+      expect_that (-> t '(number, boolean, string)', {123, true, 'hello'}), no_errors!
+      expect_that (-> t '(number, boolean, string)', {123, true, 'hello', coroutine.create ->}), no_errors!
+      expect_that (-> t '((number, boolean), (string, thread))', {{123, true}, {'hello', coroutine.create ->}}), no_errors!
 
-      expect_that (-> typed '(number, boolean, string)', nil), errors matches 'incorrect type: expected table but got nil'
-      expect_that (-> typed '(number, boolean, string)', {}), errors matches 'incorrect type: expected number but got nil'
-      expect_that (-> typed '(number, boolean, string)', {123}), errors matches 'incorrect type: expected boolean but got nil'
-      expect_that (-> typed '(number, boolean, string)', {'interloper'}), errors matches 'incorrect type: expected number but got string'
+      expect_that (-> t '(number, boolean, string)', nil), errors matches 'incorrect type: expected table but got nil'
+      expect_that (-> t '(number, boolean, string)', {}), errors matches 'incorrect type: expected number but got nil'
+      expect_that (-> t '(number, boolean, string)', {123}), errors matches 'incorrect type: expected boolean but got nil'
+      expect_that (-> t '(number, boolean, string)', {'interloper'}), errors matches 'incorrect type: expected number but got string'
 
     it 'checks structs', ->
-      expect_that (-> typed '{}', {}), no_errors!
-      expect_that (-> typed '{}', {123}), no_errors!
-      expect_that (-> typed '{}', {hello: 123}), no_errors!
-      expect_that (-> typed '{hello: string}', {hello: 'hello'}), no_errors!
-      expect_that (-> typed '{hello: {world: string}}', {hello: world: 'world'}), no_errors!
-      expect_that (-> typed '{hello: {world: string}, foo: boolean}', hello: {world:'asdf'}, foo: true), no_errors!
+      expect_that (-> t '{}', {}), no_errors!
+      expect_that (-> t '{}', {123}), no_errors!
+      expect_that (-> t '{}', {hello: 123}), no_errors!
+      expect_that (-> t '{hello: string}', {hello: 'hello'}), no_errors!
+      expect_that (-> t '{hello: {world: string}}', {hello: world: 'world'}), no_errors!
+      expect_that (-> t '{hello: {world: string}, foo: boolean}', hello: {world:'asdf'}, foo: true), no_errors!
 
-      expect_that (-> typed '{}', 132), errors matches 'incorrect type: expected table but got number'
-      expect_that (-> typed '{hello: string}', {}), errors matches 'incorrect type: expected string but got nil'
-      expect_that (-> typed '{hello: string}', hello: 123), errors matches 'incorrect type: expected string but got number'
-      expect_that (-> typed '{hello: {world: string}}', hello: 123), errors matches 'incorrect type: expected table but got number'
-      expect_that (-> typed '{hello: {world: string}}', hello: {}), errors matches 'incorrect type: expected string but got nil'
-      expect_that (-> typed '{hello: {world: string}}', hello: world: 123), errors matches 'incorrect type: expected string but got number'
-      expect_that (-> typed '{hello: {world: string}, foo: boolean}', hello: {world:'asdf'}, foo: 123), errors matches 'incorrect type: expected boolean but got number'
+      expect_that (-> t '{}', 132), errors matches 'incorrect type: expected table but got number'
+      expect_that (-> t '{hello: string}', {}), errors matches 'incorrect type: expected string but got nil'
+      expect_that (-> t '{hello: string}', hello: 123), errors matches 'incorrect type: expected string but got number'
+      expect_that (-> t '{hello: {world: string}}', hello: 123), errors matches 'incorrect type: expected table but got number'
+      expect_that (-> t '{hello: {world: string}}', hello: {}), errors matches 'incorrect type: expected string but got nil'
+      expect_that (-> t '{hello: {world: string}}', hello: world: 123), errors matches 'incorrect type: expected string but got number'
+      expect_that (-> t '{hello: {world: string}, foo: boolean}', hello: {world:'asdf'}, foo: 123), errors matches 'incorrect type: expected boolean but got number'
 
     it 'checks functions', ->
-      expect_that (-> typed '() -> nil', ->), no_errors!
-      expect_that (-> typed '() -> nil', {}), errors matches 'incorrect type: expected function but got table'
+      expect_that (-> t '() -> nil', ->), no_errors!
+      expect_that (-> t '() -> nil', {}), errors matches 'incorrect type: expected function but got table'
 
 -- import set_log_verbosity from require 'fat.logger'
 -- set_log_verbosity true

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -55,7 +55,7 @@ function_type = (type_spec) ->
   function_types[type_spec] ?? do
     -- Slow path: parse type spec
     parsed_type = parse type_spec
-    if parsed_type.<class>.__name != 'Function'
+    if not parsed_type\is Function
       error "cannot typecheck: expected a function type"
 
     function_types[type_spec] = parsed_type
@@ -420,7 +420,11 @@ named_type = (name) ->
   else
     UserType name
 
-class Primitive
+class Type
+  is: (ty) =>
+    @.<class>.__name == ty.__base.__class.__name
+
+class Primitive extends Type
   new: (@name) =>
 
   __tostring: => @name
@@ -429,14 +433,14 @@ class Primitive
     with checker_builder
       \add C_ASSERT_PRIMITIVE, @name
 
-class Any
+class Any extends Type
   __tostring: =>
     'any'
 
   checker: (checker_builder=CheckerBuilder!) =>
     checker_builder -- No checks required.
 
-class UserType
+class UserType extends Type
   new: (@name) =>
 
   __tostring: => @name
@@ -451,7 +455,7 @@ class UserType
         parsed_user_type\checker checker_builder
         \pop_building @
 
-class StringType
+class StringType extends Type
   new: (@content) =>
 
   __tostring: =>
@@ -462,7 +466,7 @@ class StringType
       \add C_ASSERT_PRIMITIVE, 'string'
       \add C_ASSERT_EQ, @content
 
-class Optional
+class Optional extends Type
   new: (@inner_type) =>
 
   __tostring: =>
@@ -474,7 +478,7 @@ class Optional
       @inner_type\checker checker_builder
       inner_skip_target\resolve_here!
 
-class Array
+class Array extends Type
   new: (@elem_type) =>
 
   __tostring: =>
@@ -499,7 +503,7 @@ class Array
       \add C_ASSERT_LEN
       \add C_POP
 
-class Tuple
+class Tuple extends Type
   new: (@elem_types) =>
 
   __tostring: =>
@@ -516,7 +520,7 @@ class Tuple
         \add C_POP
         \add C_POP
 
-class Struct
+class Struct extends Type
   new: (@fields) =>
 
   __tostring: =>
@@ -533,7 +537,7 @@ class Struct
         \add C_POP
         \add C_POP
 
-class Field
+class Field extends Type
   new: (@name, @type) =>
 
   __tostring: =>
@@ -542,7 +546,7 @@ class Field
   checker: (checker_builder=CheckerBuilder!) =>
     @type\checker checker_builder
 
-class Set
+class Set extends Type
   new: (@elem_type) =>
 
   __tostring: =>
@@ -566,7 +570,7 @@ class Set
       \add C_POP
       \add C_POP
 
-class Mapping
+class Mapping extends Type
   new: (@in_type, @out_type) =>
 
   __tostring: =>
@@ -592,7 +596,7 @@ class Mapping
       \add C_POP
 
 
-class Function
+class Function extends Type
   new: (@param_types, @return_types) =>
     @_param_checkers = nil
     @_return_checkers = nil
@@ -642,13 +646,13 @@ class Function
     with checker_builder
       \add C_ASSERT_PRIMITIVE, 'function'
 
-class Disjunction
+class Disjunction extends Type
   new: (@types) =>
 
   __tostring: =>
     table.concat [tostring ty for ty in *@types], '|'
 
-class Conjunction
+class Conjunction extends Type
   new: (@types) =>
 
   __tostring: =>

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -318,7 +318,7 @@ named_type = (name) ->
   if known_primitives[name]?
     Primitive name
   else if not name\match '^[A-Z]'
-    error "cannot use '#{name}' as custom type name: name must start with an uppercase letter"
+    error "cannot use '#{name}' as user type name: name must start with an uppercase letter"
   else
     UserType name
 
@@ -327,7 +327,7 @@ class Primitive
 
   __tostring: => @name
 
-  checker: (prog={}) =>
+  checker: (prog={}, ctx=CheckerCtx!) =>
     with prog
       [] = C_ASSERT_PRIMITIVE
       [] = @name
@@ -337,8 +337,18 @@ class UserType
 
   __tostring: => @name
 
-  checker: (prog={}) =>
-    error 'todo'
+  checker: (prog={}, ctx=CheckerCtx!) =>
+    parsed_user_type = user_types[@name]
+    if not parsed_user_type?
+      error "cannot construct type checker for #{@name}: type not defined"
+    with prog
+      if ctx\already_constructing @
+        [] = C_PUSH_CHECKER
+        [] = @name
+      else
+        ctx\push_constructing @
+        parsed_user_type\checker prog, ctx
+        ctx\pop_constructing!
 
 class Optional
   new: (@inner_type) =>
@@ -346,12 +356,12 @@ class Optional
   __tostring: =>
     "?#{@inner_type}"
 
-  checker: (prog={}) =>
+  checker: (prog={}, ctx=CheckerCtx!) =>
     with prog
       [] = C_JMP_IF_NIL
       [] = LABEL_PLACEHOLDER
       label_placeholder_index = #prog
-      @inner_type\checker prog
+      @inner_type\checker prog, ctx
 
       [label_placeholder_index] = #prog + 1
 
@@ -361,7 +371,7 @@ class Array
   __tostring: =>
     "[#{@elem_type}]"
 
-  checker: (prog={}) =>
+  checker: (prog={}, ctx=CheckerCtx!) =>
     with prog
       [] = C_ASSERT_PRIMITIVE
       [] = 'table'
@@ -374,7 +384,7 @@ class Array
       [] = C_JMP_IF_NIL
       [] = LABEL_PLACEHOLDER
       loop_exit_jump_index = #prog
-      @elem_type\checker prog
+      @elem_type\checker prog, ctx
       [] = C_POP
       [] = C_INCR
       [] = C_JMP
@@ -392,7 +402,7 @@ class Tuple
     elem_type_reprs = [ tostring elem_type for elem_type in *@elem_types ]
     "(#{table.concat elem_type_reprs, ', '})"
 
-  checker: (prog={}) =>
+  checker: (prog={}, ctx=CheckerCtx!) =>
     with prog
       [] = C_ASSERT_PRIMITIVE
       [] = 'table'
@@ -400,7 +410,7 @@ class Tuple
         [] = C_PUSH
         [] = i
         [] = C_GET_FIELD
-        @elem_types[i]\checker prog
+        @elem_types[i]\checker prog, ctx
         [] = C_POP
         [] = C_INCR
         [] = C_POP
@@ -412,7 +422,7 @@ class Struct
     field_reprs = [ tostring field for field in *@fields ]
     "{#{table.concat field_reprs, ', '}}"
 
-  checker: (prog={}) =>
+  checker: (prog={}, ctx=CheckerCtx!) =>
     with prog
       [] = C_ASSERT_PRIMITIVE
       [] = 'table'
@@ -420,7 +430,7 @@ class Struct
         [] = C_PUSH
         [] = field.name
         [] = C_GET_FIELD
-        field\checker prog
+        field\checker prog, ctx
         [] = C_POP
         [] = C_POP
 
@@ -430,8 +440,8 @@ class Field
   __tostring: =>
     "#{@name}: #{@type}"
 
-  checker: (prog={}) =>
-    @type\checker prog
+  checker: (prog={}, ctx=CheckerCtx!) =>
+    @type\checker prog, ctx
 
 class Set
   new: (@elem_type) =>
@@ -439,7 +449,7 @@ class Set
   __tostring: =>
     "{#{@elem_type}}"
 
-  checker: (prog={}) =>
+  checker: (prog={}, ctx=CheckerCtx!) =>
     with prog
       [] = C_ASSERT_PRIMITIVE
       [] = 'table'
@@ -453,7 +463,7 @@ class Set
       [] = LABEL_PLACEHOLDER
       [] = C_ASSERT_TRUTHY
       [] = C_POP
-      @elem_type\checker prog
+      @elem_type\checker prog, ctx
 
       [] = C_NEXT
       [] = C_JMP
@@ -469,7 +479,7 @@ class Mapping
   __tostring: =>
     "{#{@in_type} -> #{@out_type}}"
 
-  checker: (prog={}) =>
+  checker: (prog={}, ctx=CheckerCtx!) =>
     with prog
       [] = C_ASSERT_PRIMITIVE
       [] = 'table'
@@ -482,7 +492,7 @@ class Mapping
       loop_exit_jump_index = #prog + 1
       [] = LABEL_PLACEHOLDER
 
-      @out_type\checker prog
+      @out_type\checker prog, ctx
       [] = C_POP
       @in_type\checker prog
 
@@ -521,10 +531,26 @@ class Function
           [] = tostring return_type
         [] = '>'
 
-  checker: (prog={}) =>
+  checker: (prog={}, ctx=CheckerCtx!) =>
     with prog
       [] = C_ASSERT_PRIMITIVE
       [] = 'function'
+
+class CheckerCtx
+  new: =>
+    @user_type_stack = {}
+
+  already_constructing: (user_type) =>
+    for user_type_being_checked in *@user_type_stack
+      if user_type.name == user_type_being_checked.name
+        return true
+    false
+
+  push_constructing: (user_type) =>
+    @user_type_stack[] = user_type
+
+  pop_constructing: =>
+    @user_type_stack[#@user_type_stack] = nil
 
 C_PUSH = <tostring>: => '<push>'
 C_POP = <tostring>: => '<pop>'
@@ -536,6 +562,7 @@ C_INCR = <tostring>: => '<incr>'
 C_NEXT = <tostring>: => '<next>'
 C_JMP = <tostring>: => '<jmp>'
 C_JMP_IF_NIL = <tostring>: => '<jnil>'
+C_PUSH_CHECKER = <tostring>: => '<push-checker>'
 V_NIL = <tostring>: => 'nil'
 
 LABEL_PLACEHOLDER = <tostring>: => '<LABEL-PLACEHOLDER>'
@@ -552,23 +579,37 @@ check_error = (...) ->
     stack[i] = nil
   stack_size = 0
   error ...
+
+checker_stack = {}
+
 instruction_counts = {}
-check = (check_prog, value) ->
-  stack_size = 1
-  stack[1] = value
+
+check = (check_prog, value, root=true) ->
+  if root
+    -- Prime stack.
+    stack_size = 1
+    stack[1] = value
+  initial_stack_size = stack_size
 
   with check_prog
+    if DEBUG
+      print '=== CHECKER START ==='
     local pc = 0
     n_instructions = #check_prog
-    while pc < n_instructions
+    while true
+      if pc >= n_instructions
+        break
       pc += 1
+
       if COLLECT_STATS
         instruction_counts[ [pc] ] = if v = instruction_counts[ [pc] ]
           v + 1
         else
           1
+
       if DEBUG
         print "stack state #{[pc]}@#{pc} [#{stack_size}]:\n\t#{table.concat [ "#{i}:\t#{repr stack[i]}" for i = 1, stack_size], '\n\t'}"
+
       switch [pc]
         when C_PUSH
           pc += 1
@@ -612,20 +653,41 @@ check = (check_prog, value) ->
             pc += 1
           else
             pc = [pc + 1] - 1
+        when C_PUSH_CHECKER
+          pc += 1
+          checker = type_checkers[ [pc] ]
+          if not checker?
+            error "cannot typecheck #{[pc]}: type not defined"
+          check checker, nil, false
         else
           check_error "internal error: illegal type-checker VM instruction #{[pc]}@#{pc}"
   if DEBUG
     print "FINAL stack state #{check_prog[pc]}@#{pc} [#{stack_size}]:\n\t#{table.concat [ "#{i}:\t#{repr stack[i]}" for i = 1, stack_size], '\n\t'}"
-  assert stack_size == 1, "internal error: value stack is not 1"
-  stack[1] = nil
-  stack_size = 0
 
+  assert stack_size == initial_stack_size, "internal error: value stack is not 1"
+  if root
+    -- Reset stack.
+    stack[1] = nil
+    stack_size = 0
+
+user_types = {}
 export declare_type = (name, type_spec) ->
+  if not name?
+    error "declare_type requires a name"
+  if 'string' != type name
+    error "declare_type requires a string name"
+  if not type_spec?
+    error "declare_type requires a type_spec"
+  if 'string' != type type_spec
+    error "declare_type requires a string type_spec"
+
   if not (name\sub 1, 1)\match '^[A-Z_]$'
-    error "cannot declare type '#{name}': custom types must start with uppercase or '_'"
-  if type_checkers[name]?
+    error "cannot declare type '#{name}': user types must start with uppercase or '_'"
+  if user_types[name]?
     error "cannot redefine type '#{name}'"
-  type_checkers[name] = type_checker type_spec
+  parsed_type = parse type_spec
+  user_types[name] = parsed_type
+  type_checkers[name] = parsed_type\checker!
 
 export deactivate = ->
   T = (_, fn) -> fn
@@ -712,11 +774,11 @@ spec ->
         expect_that (parse 'function'), deep_eq Primitive type ->
         expect_that (parse 'thread'), deep_eq Primitive type coroutine.create ->
 
-      it 'accepts custom types', ->
-        expect_that (parse 'CustomType'), deep_eq UserType 'CustomType'
+      it 'accepts user types', ->
+        expect_that (parse 'UserType'), deep_eq UserType 'UserType'
 
       it 'rejects unknown primitives', ->
-        expect_that (-> parse 'custom'), errors matches [[cannot use 'custom' as custom type name: name must start with an uppercase letter]]
+        expect_that (-> parse 'user'), errors matches [[cannot use 'user' as user type name: name must start with an uppercase letter]]
 
       it 'rejects incomplete types', ->
         expect_that (-> parse '['), errors matches [[unexpected EOF]]
@@ -737,10 +799,10 @@ spec ->
       it 'accepts tuples', ->
         expect_that (parse '()'), deep_eq Tuple {}
         expect_that (parse '(nil, number)'), deep_eq Tuple { (Primitive 'nil'), Primitive 'number' }
-        expect_that (parse '((nil, number), string, (Custom, table))'), deep_eq Tuple {
+        expect_that (parse '((nil, number), string, (User, table))'), deep_eq Tuple {
           Tuple { (Primitive 'nil'), (Primitive 'number') },
           Primitive 'string',
-          Tuple { (UserType 'Custom'), (Primitive 'table') },
+          Tuple { (UserType 'User'), (Primitive 'table') },
         }
 
       it 'accepts sets', ->
@@ -768,14 +830,6 @@ spec ->
         expect_that (parse '() -> nil'), deep_eq Function {}, {}
         expect_that (parse '(string) -> number'), deep_eq Function {Primitive 'string'}, {Primitive 'number'}
         expect_that (parse '(string) -> (number) -> boolean'), deep_eq Function {Primitive 'string'}, {Function {Primitive 'number'}, {Primitive 'boolean'}}
-
-  describe 'declare_type', ->
-    it 'rejects false primitives', ->
-      expect_that (-> declare_type 'custom'), errors matches 'custom types must start with uppercase'
-
-    -- it 'rejects redefinition', ->
-    --   declare_type 'Custom', 'number'
-    --   expect_that (-> declare_type 'Custom'), errors matches [[cannot redefine type 'Custom']]
 
   describe 'T', ->
     it 'requires two arguments', ->
@@ -858,6 +912,29 @@ spec ->
     it 'checks functions', ->
       expect_that (-> T '() -> nil', ->), no_errors!
       expect_that (-> T '() -> nil', {}), errors matches 'incorrect type: expected function but got table'
+
+  describe 'declare_type', ->
+    it 'requires two arguments', ->
+      expect_that (-> declare_type!), errors matches 'declare_type requires a name'
+      expect_that (-> declare_type 'TwoArgs'), errors matches 'declare_type requires a type_spec'
+      expect_that (-> declare_type 123, 'string'), errors matches 'declare_type requires a string name'
+      expect_that (-> declare_type 'TwoArgs', 123), errors matches 'declare_type requires a string type_spec'
+
+    it 'rejects false primitives', ->
+      expect_that (-> declare_type 'user', 'string'), errors matches 'user types must start with uppercase'
+
+    it 'rejects redefinition', ->
+      declare_type 'AlreadyDefined', 'number'
+      expect_that (-> declare_type 'AlreadyDefined', 'string'), errors matches [[cannot redefine type 'AlreadyDefined']]
+
+    it 'supports non-recursive types', ->
+      declare_type 'NonRecursive', '[string]'
+      expect_that (-> T '[NonRecursive]', {{'hello'}}), no_errors!
+
+    it 'support recursive types', ->
+      declare_type 'Recursive', '[?Recursive]'
+      expect_that (-> T 'Recursive', {{{{{nil}}}}}), no_errors!
+      expect_that (-> T 'Recursive', {{{{{'asdf'}}}}}), errors matches 'incorrect type: expected table but got string'
 
   describe 'stats', ->
     it 'has the correct type', ->

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -495,7 +495,7 @@ check = (check_prog, value) ->
   with check_prog
     local pc = 0
     n_instructions = #check_prog
-    while pc <= n_instructions
+    while pc < n_instructions
       pc += 1
       switch [pc]
         when C_PUSH
@@ -523,6 +523,8 @@ check = (check_prog, value) ->
             pc += 1
           else
             pc = [pc + 1] - 1
+        else
+          error "internal error: illegal type-checker VM instruction #{[pc]}@#{pc}"
 
 export declare_type = (name, type_spec) ->
   if not (name\sub 1, 1)\match '^[A-Z_]$'

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -1134,5 +1134,5 @@ spec ->
 
 -- import set_log_verbosity from require 'fat.logger'
 -- set_log_verbosity true
--- DEBUG = true
+DEBUG = true
 (require 'spec').run_tests select 1, ...

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -18,12 +18,11 @@ type_checker = (type_spec) ->
   type_checkers[type_spec] ?? do
     -- Slow path: parse and generate checker
     parsed_type = parse type_spec
-    checker = parsed_type\checker!
+    checker = parsed_type\checker!\build!
 
     type_checkers[type_spec] = checker
-    validate checker
     if DEBUG
-      print "got checker:\n\t#{table.concat ["#{i}:\t#{repr checker[i]}" for i = 1, #checker], '\n\t'}"
+      print "got checker:\n\t#{checker_program_repr checker}"
     checker
 
 parse = (type_spec) ->
@@ -327,28 +326,24 @@ class Primitive
 
   __tostring: => @name
 
-  checker: (prog={}, ctx=CheckerCtx!) =>
-    with prog
-      [] = C_ASSERT_PRIMITIVE
-      [] = @name
+  checker: (checker_builder=CheckerBuilder!) =>
+    with checker_builder
+      \add C_ASSERT_PRIMITIVE, @name
 
 class UserType
   new: (@name) =>
 
   __tostring: => @name
 
-  checker: (prog={}, ctx=CheckerCtx!) =>
-    parsed_user_type = user_types[@name]
-    if not parsed_user_type?
-      error "cannot construct type checker for #{@name}: type not defined"
-    with prog
-      if ctx\already_constructing @
-        [] = C_PUSH_CHECKER
-        [] = @name
+  checker: (checker_builder=CheckerBuilder!) =>
+    with checker_builder
+      parsed_user_type = user_types[@name]
+      if not parsed_user_type? or checker_builder\already_building @
+        \add C_PUSH_CHECKER, @name
       else
-        ctx\push_constructing @
-        parsed_user_type\checker prog, ctx
-        ctx\pop_constructing!
+        \push_building @
+        parsed_user_type\checker checker_builder
+        \pop_building @
 
 class Optional
   new: (@inner_type) =>
@@ -356,14 +351,11 @@ class Optional
   __tostring: =>
     "?#{@inner_type}"
 
-  checker: (prog={}, ctx=CheckerCtx!) =>
-    with prog
-      [] = C_JMP_IF_NIL
-      [] = LABEL_PLACEHOLDER
-      label_placeholder_index = #prog
-      @inner_type\checker prog, ctx
-
-      [label_placeholder_index] = #prog + 1
+  checker: (checker_builder=CheckerBuilder!) =>
+    with checker_builder
+      inner_skip_target = \add_with_unresolved_target C_JMP_IF_NIL
+      @inner_type\checker checker_builder
+      inner_skip_target\resolve_here!
 
 class Array
   new: (@elem_type) =>
@@ -371,29 +363,23 @@ class Array
   __tostring: =>
     "[#{@elem_type}]"
 
-  checker: (prog={}, ctx=CheckerCtx!) =>
-    with prog
-      [] = C_ASSERT_PRIMITIVE
-      [] = 'table'
-      [] = C_PUSH
-      [] = 1
+  checker: (checker_builder=CheckerBuilder!) =>
+    with checker_builder
+      \add C_ASSERT_PRIMITIVE, 'table'
+      \add C_PUSH, 1
 
-      [] = C_GET_FIELD
-      loop_start = #prog
+      loop_start = \add_labelled C_GET_FIELD
 
-      [] = C_JMP_IF_NIL
-      [] = LABEL_PLACEHOLDER
-      loop_exit_jump_index = #prog
-      @elem_type\checker prog, ctx
-      [] = C_POP
-      [] = C_INCR
-      [] = C_JMP
-      [] = loop_start
+      loop_exit_target = \add_with_unresolved_target C_JMP_IF_NIL
+      @elem_type\checker checker_builder
+      \add C_POP
+      \add C_INCR
+      \add C_JMP, loop_start.index
 
-      [loop_exit_jump_index] = #prog + 1
-      [] = C_POP
-      [] = C_ASSERT_LEN
-      [] = C_POP
+      loop_exit_target\resolve_here!
+      \add C_POP
+      \add C_ASSERT_LEN
+      \add C_POP
 
 class Tuple
   new: (@elem_types) =>
@@ -402,18 +388,16 @@ class Tuple
     elem_type_reprs = [ tostring elem_type for elem_type in *@elem_types ]
     "(#{table.concat elem_type_reprs, ', '})"
 
-  checker: (prog={}, ctx=CheckerCtx!) =>
-    with prog
-      [] = C_ASSERT_PRIMITIVE
-      [] = 'table'
+  checker: (checker_builder=CheckerBuilder!) =>
+    with checker_builder
+      \add C_ASSERT_PRIMITIVE, 'table'
       for i = 1, #@elem_types
-        [] = C_PUSH
-        [] = i
-        [] = C_GET_FIELD
-        @elem_types[i]\checker prog, ctx
-        [] = C_POP
-        [] = C_INCR
-        [] = C_POP
+        \add C_PUSH, i
+        \add C_GET_FIELD
+        @elem_types[i]\checker checker_builder
+        \add C_POP
+        \add C_INCR
+        \add C_POP
 
 class Struct
   new: (@fields) =>
@@ -422,17 +406,15 @@ class Struct
     field_reprs = [ tostring field for field in *@fields ]
     "{#{table.concat field_reprs, ', '}}"
 
-  checker: (prog={}, ctx=CheckerCtx!) =>
-    with prog
-      [] = C_ASSERT_PRIMITIVE
-      [] = 'table'
+  checker: (checker_builder=CheckerBuilder!) =>
+    with checker_builder
+      \add C_ASSERT_PRIMITIVE, 'table'
       for field in *@fields
-        [] = C_PUSH
-        [] = field.name
-        [] = C_GET_FIELD
-        field\checker prog, ctx
-        [] = C_POP
-        [] = C_POP
+        \add C_PUSH, field.name
+        \add C_GET_FIELD
+        field\checker checker_builder
+        \add C_POP
+        \add C_POP
 
 class Field
   new: (@name, @type) =>
@@ -440,8 +422,8 @@ class Field
   __tostring: =>
     "#{@name}: #{@type}"
 
-  checker: (prog={}, ctx=CheckerCtx!) =>
-    @type\checker prog, ctx
+  checker: (checker_builder=CheckerBuilder!) =>
+    @type\checker checker_builder
 
 class Set
   new: (@elem_type) =>
@@ -449,29 +431,23 @@ class Set
   __tostring: =>
     "{#{@elem_type}}"
 
-  checker: (prog={}, ctx=CheckerCtx!) =>
-    with prog
-      [] = C_ASSERT_PRIMITIVE
-      [] = 'table'
-      [] = C_PUSH
-      [] = V_NIL
-      [] = C_NEXT
+  checker: (checker_builder=CheckerBuilder!) =>
+    with checker_builder
+      \add C_ASSERT_PRIMITIVE, 'table'
+      \add C_PUSH, V_NIL
+      \add C_NEXT
 
-      loop_start = #prog + 1
-      [] = C_JMP_IF_NIL
-      loop_exit_jump_index = #prog + 1
-      [] = LABEL_PLACEHOLDER
-      [] = C_ASSERT_TRUTHY
-      [] = C_POP
-      @elem_type\checker prog, ctx
+      loop_start_label = \add_with_unresolved_target C_JMP_IF_NIL
+      \add C_ASSERT_TRUTHY
+      \add C_POP
+      @elem_type\checker checker_builder
 
-      [] = C_NEXT
-      [] = C_JMP
-      [] = loop_start
+      \add C_NEXT
+      \add C_JMP, loop_start_label.index
 
-      [loop_exit_jump_index] = #prog + 1
-      [] = C_POP
-      [] = C_POP
+      loop_start_label\resolve_here!
+      \add C_POP
+      \add C_POP
 
 class Mapping
   new: (@in_type, @out_type) =>
@@ -479,30 +455,24 @@ class Mapping
   __tostring: =>
     "{#{@in_type} -> #{@out_type}}"
 
-  checker: (prog={}, ctx=CheckerCtx!) =>
-    with prog
-      [] = C_ASSERT_PRIMITIVE
-      [] = 'table'
-      [] = C_PUSH
-      [] = V_NIL
-      [] = C_NEXT
+  checker: (checker_builder=CheckerBuilder!) =>
+    with checker_builder
+      \add C_ASSERT_PRIMITIVE, 'table'
+      \add C_PUSH, V_NIL
+      \add C_NEXT
 
-      loop_start = #prog + 1
-      [] = C_JMP_IF_NIL
-      loop_exit_jump_index = #prog + 1
-      [] = LABEL_PLACEHOLDER
+      loop_start_label = \add_with_unresolved_target C_JMP_IF_NIL
 
-      @out_type\checker prog, ctx
-      [] = C_POP
-      @in_type\checker prog
+      @out_type\checker checker_builder
+      \add C_POP
+      @in_type\checker checker_builder
 
-      [] = C_NEXT
-      [] = C_JMP
-      [] = loop_start
+      \add C_NEXT
+      \add C_JMP, loop_start_label.index
 
-      [loop_exit_jump_index] = #prog + 1
-      [] = C_POP
-      [] = C_POP
+      loop_start_label\resolve_here!
+      \add C_POP
+      \add C_POP
 
 
 class Function
@@ -531,26 +501,61 @@ class Function
           [] = tostring return_type
         [] = '>'
 
-  checker: (prog={}, ctx=CheckerCtx!) =>
-    with prog
-      [] = C_ASSERT_PRIMITIVE
-      [] = 'function'
+  checker: (checker_builder=CheckerBuilder!) =>
+    with checker_builder
+      \add C_ASSERT_PRIMITIVE, 'function'
 
-class CheckerCtx
+class CheckerBuilder
   new: =>
+    @instructions = {}
     @user_type_stack = {}
 
-  already_constructing: (user_type) =>
+  add: (op, arg='_') =>
+    @instructions[] = op
+    @instructions[] = arg
+
+  add_labelled: (op, arg='_') =>
+    label = @make_label!
+    @add op, arg
+    label
+
+  add_with_unresolved_target: (op) =>
+    label = @make_label!
+    @add op, LABEL_PLACEHOLDER
+    label
+
+  make_label: =>
+    Label @instructions
+
+  build: =>
+    @validate!
+    @instructions
+
+  validate: =>
+    for instruction in *@instructions
+      if instruction == LABEL_PLACEHOLDER
+        error "unresolved placeholder in check program:\n#{repr @instructions}"
+
+  already_building: (user_type) =>
     for user_type_being_checked in *@user_type_stack
       if user_type.name == user_type_being_checked.name
         return true
     false
 
-  push_constructing: (user_type) =>
+  push_building: (user_type) =>
     @user_type_stack[] = user_type
 
-  pop_constructing: =>
+  pop_building: (user_type) =>
+    if @user_type_stack[#@user_type_stack] != user_type
+      error "internal error: user type stack mismanaged, expected #{user_type.name} at the top of #{repr @user_type_stack}"
     @user_type_stack[#@user_type_stack] = nil
+
+class Label
+  new: (@instructions) =>
+    @index = #@instructions + 1
+
+  resolve_here: =>
+    @instructions[@index + 1] = #@instructions + 1
 
 C_PUSH = <tostring>: => '<push>'
 C_POP = <tostring>: => '<pop>'
@@ -565,67 +570,72 @@ C_JMP_IF_NIL = <tostring>: => '<jnil>'
 C_PUSH_CHECKER = <tostring>: => '<push-checker>'
 V_NIL = <tostring>: => 'nil'
 
-LABEL_PLACEHOLDER = <tostring>: => '<LABEL-PLACEHOLDER>'
+checker_program_repr = (checker) ->
+  table.concat ["#{i}:\t#{repr checker[i]}\t#{checker[i+1]}" for i = 1, #checker, 2], '\n\t'
 
-validate = (check_prog) ->
-  for instruction in *check_prog
-    if instruction == LABEL_PLACEHOLDER
-      error "unresolved placeholder in check program:\n#{repr check_prog}"
+LABEL_PLACEHOLDER = <tostring>: => '<LABEL-PLACEHOLDER>'
 
 stack_size = 0
 stack = {}
+num_running_checkers = 0
 check_error = (...) ->
   for i = 1, stack_size
     stack[i] = nil
   stack_size = 0
+  num_running_checkers = 0
   error ...
-
-checker_stack = {}
 
 instruction_counts = {}
 
+export MAX_CHECKER_DEPTH = 1000
 check = (check_prog, value, root=true) ->
+
   if root
     -- Prime stack.
     stack_size = 1
     stack[1] = value
+    num_running_checkers = 0
   initial_stack_size = stack_size
 
+  initial_num_running_checkers = num_running_checkers
+  num_running_checkers += 1
+
+  if num_running_checkers >= MAX_CHECKER_DEPTH
+    error "type checker recursed too many times (#{num_running_checkers} times). If this is okay, increase the MAX_CHECKER_DEPTH"
+
   with check_prog
-    if DEBUG
-      print '=== CHECKER START ==='
-    local pc = 0
+    local pc = -1
     n_instructions = #check_prog
     while true
+      pc += 2
       if pc >= n_instructions
         break
-      pc += 1
 
+      instruction = [pc]
       if COLLECT_STATS
-        instruction_counts[ [pc] ] = if v = instruction_counts[ [pc] ]
+        instruction_counts[instruction] = if v = instruction_counts[instruction]
           v + 1
         else
           1
 
       if DEBUG
-        print "stack state #{[pc]}@#{pc} [#{stack_size}]:\n\t#{table.concat [ "#{i}:\t#{repr stack[i]}" for i = 1, stack_size], '\n\t'}"
+        print "stack state #{instruction}@#{pc} [#{stack_size}]:\n\t#{table.concat [ "#{i}:\t#{repr stack[i]}" for i = 1, stack_size], '\n\t'}"
 
-      switch [pc]
+      switch instruction
         when C_PUSH
-          pc += 1
-          value = [pc]
-          if value == V_NIL
-            value = nil
+          arg = [pc + 1]
+          if arg == V_NIL
+            arg = nil
           stack_size += 1
-          stack[stack_size] = value
+          stack[stack_size] = arg
         when C_POP
           stack[stack_size] = nil
           stack_size -= 1
         when C_ASSERT_PRIMITIVE
           ty = type stack[stack_size]
-          pc += 1
-          if ty != [pc]
-            check_error "incorrect type: expected #{check_prog[pc]} but got #{ty}"
+          arg = [pc + 1]
+          if ty != arg
+            check_error "incorrect type: expected #{arg} but got #{ty}"
         when C_ASSERT_TRUTHY
           if not stack[stack_size]
             check_error "incorrect type: expected a truthy value but got #{stack[stack_size]}"
@@ -647,28 +657,31 @@ check = (check_prog, value, root=true) ->
           stack_size += 1
           stack[stack_size] = value
         when C_JMP
-          pc = [pc + 1] - 1
+          pc = [pc + 1] - 2
         when C_JMP_IF_NIL
           if stack[stack_size]?
-            pc += 1
+            -- No branch.
           else
-            pc = [pc + 1] - 1
+            pc = [pc + 1] - 2
         when C_PUSH_CHECKER
-          pc += 1
-          checker = type_checkers[ [pc] ]
+          arg = [pc + 1]
+          checker = type_checkers[arg]
           if not checker?
-            error "cannot typecheck #{[pc]}: type not defined"
+            error "cannot typecheck #{arg}: type not defined"
           check checker, nil, false
         else
           check_error "internal error: illegal type-checker VM instruction #{[pc]}@#{pc}"
-  if DEBUG
-    print "FINAL stack state #{check_prog[pc]}@#{pc} [#{stack_size}]:\n\t#{table.concat [ "#{i}:\t#{repr stack[i]}" for i = 1, stack_size], '\n\t'}"
+    if DEBUG
+      print "FINAL stack state #{check_prog[pc-2]}@#{pc-2} [#{stack_size}]:\n\t#{table.concat [ "#{i}:\t#{repr stack[i]}" for i = 1, stack_size], '\n\t'}"
 
-  assert stack_size == initial_stack_size, "internal error: value stack is not 1"
-  if root
-    -- Reset stack.
-    stack[1] = nil
-    stack_size = 0
+    num_running_checkers -= 1
+    assert num_running_checkers == initial_num_running_checkers, "internal error: checker depth incorrectly handled: expected #{initial_num_running_checkers} but got #{num_running_checkers}"
+    assert stack_size == initial_stack_size, "internal error: value stack incorrectly handled"
+    if root
+      -- Reset stack.
+      stack[1] = nil
+      stack_size = 0
+  nil
 
 user_types = {}
 export declare_type = (name, type_spec) ->
@@ -687,7 +700,7 @@ export declare_type = (name, type_spec) ->
     error "cannot redefine type '#{name}'"
   parsed_type = parse type_spec
   user_types[name] = parsed_type
-  type_checkers[name] = parsed_type\checker!
+  type_checkers[name] = parsed_type\checker!\build!
 
 export deactivate = ->
   T = (_, fn) -> fn
@@ -931,10 +944,15 @@ spec ->
       declare_type 'NonRecursive', '[string]'
       expect_that (-> T '[NonRecursive]', {{'hello'}}), no_errors!
 
-    it 'support recursive types', ->
+    it 'supports recursive types', ->
       declare_type 'Recursive', '[?Recursive]'
       expect_that (-> T 'Recursive', {{{{{nil}}}}}), no_errors!
       expect_that (-> T 'Recursive', {{{{{'asdf'}}}}}), errors matches 'incorrect type: expected table but got string'
+
+      declare_type 'MutuallyRecursive1', '?MutuallyRecursive2'
+      declare_type 'MutuallyRecursive2', 'MutuallyRecursive1'
+      expect_that (-> T 'MutuallyRecursive1', nil), no_errors!
+      expect_that (-> T 'MutuallyRecursive1', 'asdf'), errors matches 'type checker recursed too many times'
 
   describe 'stats', ->
     it 'has the correct type', ->

--- a/quicktype.yue
+++ b/quicktype.yue
@@ -47,13 +47,24 @@ class Parser
       error "unexpected EOF"
     if token.type != expected_token
       error "expected #{expected_token}"
-    token.value ?? 0
+    token.value ?? token.type
 
   select: (options) =>
     next_token = @lexer\peek!
-    for option in *options
+
+    i = 1
+    while options[i]
+      option = options[i]
       if option.token == next_token.type
-        return option.action!
+        return if action = option.action
+          action!
+        else
+          option.token
+      i += 1
+
+    if options.otherwise?
+      return options.otherwise!
+
     options_repr = table.concat [ tostring option.token for option in *options ], ', '
     error "expected one of #{options_repr}, got #{next_token.type}"
 
@@ -69,24 +80,27 @@ class Parser
           [] = token.value ?? 0
         else if action?
           [] = action!
+        else
+          error "sequence element must have expected_token or action"
 
 class TypeSpecParser extends Parser
+
   parse: =>
     @parse_type!
 
   parse_type: =>
     @select
       * token: T_NAME
-        action: @\parse_name
+        action: @\parse_named_type
       * token: T_BRACKET_OPEN
         action: @\parse_list
       * token: T_PAREN_OPEN
         action: @\parse_tuple
+      * token: T_BRACE_OPEN
+        action: @\parse_table
 
-  parse_name: =>
-    name_token = @lexer\next!
-    assert T_NAME == name_token.type
-    name_token.value
+  parse_named_type: =>
+    named_type @expect T_NAME
 
   parse_list: =>
     {_, elem_type, _} = @sequence
@@ -102,68 +116,116 @@ class TypeSpecParser extends Parser
       * token: T_PAREN_CLOSE
     Tuple elem_types
 
+  parse_table: =>
+    {_, table, _} = @sequence
+      * token: T_BRACE_OPEN
+      * action: @\parse_table_content
+      * token: T_BRACE_CLOSE
+    table
+
+  parse_table_content: =>
+    first_elem = @select
+      * token: T_NAME
+        action: -> @expect T_NAME
+      * token: T_BRACE_CLOSE
+        action: -> nil
+      otherwise: @\parse_type
+    if first_elem == nil
+      return Struct {}
+
+    second_elem = @select
+      * token: T_BRACE_CLOSE
+        action: -> 'set'
+      * token: T_ARROW
+        action: -> 'mapping'
+      * token: T_COLON
+        action: -> 'struct'
+
+    switch second_elem
+      when 'set'
+        if 'string' == type first_elem
+          first_elem = named_type first_elem
+        Set first_elem
+      when 'mapping'
+        if 'string' == type first_elem
+          first_elem = named_type first_elem
+        { _, maps_to } = @sequence
+          * token: T_ARROW
+          * action: @\parse_type
+        Mapping first_elem, maps_to
+      when 'struct'
+        @expect T_COLON
+        first_type = @parse_named_type!
+        first_field = Field first_elem, first_type
+        if @lexer\peek!.type == T_COMMA
+          @expect T_COMMA
+        remainder = @select
+          * token: T_BRACE_CLOSE
+            action: -> nil
+          * token: T_NAME
+            action: -> @parse_repeat_separated @\parse_field, T_COMMA
+        if remainder?
+          Struct { first_field, ...remainder}
+        else
+          Struct { first_field }
+      else
+        error "internal error: unexpected symbol: #{repr second_elem}"
+
+  parse_field: =>
+    {name, _, type} = @sequence
+      * token: T_NAME
+      * token: T_COLON
+      * action: @\parse_type
+    Field name, type
+
 -- Tokens
-T_PAREN_OPEN = <tostring>: => "<paren_open>"
-T_PAREN_CLOSE = <tostring>: => "<paren_close>"
-T_BRACE_OPEN = <tostring>: => "<brace_open>"
-T_BRACE_CLOSE = <tostring>: => "<brace_close>"
-T_BRACKET_OPEN = <tostring>: => "<bracket_open>"
-T_BRACKET_CLOSE = <tostring>: => "<bracket_close>"
-T_COMMA = <tostring>: => "<comma>"
-T_ARROW = <tostring>: => "<arrow>"
+T_PAREN_OPEN = <tostring>: => "'('"
+T_PAREN_CLOSE = <tostring>: => "')'"
+T_BRACE_OPEN = <tostring>: => "'{'"
+T_BRACE_CLOSE = <tostring>: => "'}'"
+T_BRACKET_OPEN = <tostring>: => "'['"
+T_BRACKET_CLOSE = <tostring>: => "']'"
+T_COMMA = <tostring>: => "','"
+T_COLON = <tostring>: => "':'"
+T_ARROW = <tostring>: => "'->'"
 T_NAME = <tostring>: => "<name>"
 
 class Lexer
   new: (type_spec) =>
+    @index = 1
     @done = false
     @peeked = nil
-    @known_primitives =
-      nil: true
-      boolean: true
-      number: true
-      string: true
-      function: true
-      table: true
-      thread: true
     @tokens = coroutine.wrap ->
-      index = 1
-      while index <= #type_spec
-        ty, value, bytes_consumed = if whitespace = type_spec\match '^[ \t\r\n]+', index
-          nil, whitespace, #whitespace
-        else if type_spec\match '^%(', index
-          T_PAREN_OPEN, '(', 1
-        else if type_spec\match '^%)', index
-          T_PAREN_CLOSE, ')', 1
-        else if type_spec\match '^,', index
-          T_COMMA, ',', 1
-        else if type_spec\match '^{', index
-          T_BRACE_OPEN, '{', 1
-        else if type_spec\match '^}', index
-          T_BRACE_CLOSE, '}', 1
-        else if type_spec\match '^%[', index
-          T_BRACKET_OPEN, '[', 1
-        else if type_spec\match '^]', index
-          T_BRACKET_CLOSE, ']', 1
-        else if type_spec\match '^->', index
-          T_ARROW, '->', 2
-        else if name = type_spec\match '^([a-zA-Z_][a-zA-Z0-9_]*)', index
-          if @known_primitives[name]?
-            T_NAME, (Primitive name), #name
-          else if not name\match '^[A-Z]'
-            error "cannot use '#{name}' as custom type name: name must start with an uppercase letter"
-          else
-            T_NAME, (UserType name), #name
+      while @index <= #type_spec
+        ty, value, bytes_consumed = if whitespace = type_spec\match '^[ \t\r\n]+', @index
+          nil, nil, #whitespace
+        else if match = type_spec\match '^%(', @index
+          T_PAREN_OPEN, nil, #match
+        else if match = type_spec\match '^%)', @index
+          T_PAREN_CLOSE, nil, #match
+        else if match = type_spec\match '^,', @index
+          T_COMMA, nil, #match
+        else if match = type_spec\match '^{', @index
+          T_BRACE_OPEN, nil, #match
+        else if match = type_spec\match '^}', @index
+          T_BRACE_CLOSE, nil, #match
+        else if match = type_spec\match '^%[', @index
+          T_BRACKET_OPEN, nil, #match
+        else if match = type_spec\match '^]', @index
+          T_BRACKET_CLOSE, nil, #match
+        else if match = type_spec\match '^:', @index
+          T_COLON, nil, #match
+        else if match = type_spec\match '^->', @index
+          T_ARROW, nil, #match
+        else if name = type_spec\match '^([a-zA-Z_][a-zA-Z0-9_]*)', @index
+          T_NAME, name, #name
         else
-          error "unrecognised character '#{type_spec\sub index, index}' in type spec '#{type_spec}"
+          error "unrecognised character '#{type_spec\sub @index, @index}' in type spec '#{type_spec}"
 
-        index += bytes_consumed
-        switch ty
-          when nil
-            continue
-          when T_NAME
-            coroutine.yield Symbol ty, value
-          else
-            coroutine.yield Symbol ty
+        @index += bytes_consumed
+        if not ty?
+          continue
+        coroutine.yield Symbol ty, value
 
   peek: =>
     if @done
@@ -191,6 +253,17 @@ class Lexer
         @done = true
       ret
 
+  snapshot: =>
+    Snapshot @index, @peeked
+
+  restore: (snapshot) =>
+    { :index, :peeked } = snapshot
+    @index = index
+    @peeked = peeked
+
+class Snapshot
+  new: (@index, @peeked) =>
+
 class Symbol
   new: (@type, @value=nil) =>
 
@@ -200,17 +273,35 @@ class Symbol
     else
       "#{@type}"
 
+known_primitives =
+  nil: true
+  boolean: true
+  number: true
+  string: true
+  function: true
+  table: true
+  thread: true
+named_type = (name) ->
+  if not name.match?
+    error repr name
+  if known_primitives[name]?
+    Primitive name
+  else if not name\match '^[A-Z]'
+    error "cannot use '#{name}' as custom type name: name must start with an uppercase letter"
+  else
+    UserType name
+
 class Primitive
   new: (@name) =>
 
   __len: => #@name
 
-  __tostring: => @name
+  __tostring: => 'P' .. @name
 
 class UserType
   new: (@name) =>
 
-  __tostring: => @name
+  __tostring: => 'U' .. @name
 
 class List
   new: (@elem_type) =>
@@ -224,6 +315,31 @@ class Tuple
   __tostring: =>
     elem_type_reprs = [ tostring elem_type for elem_type in *@elem_types ]
     "(#{table.concat elem_type_reprs, ', '})"
+
+class Struct
+  new: (@fields) =>
+
+  __tostring: =>
+    field_reprs = [ tostring field for field in *@fields ]
+    "{#{table.concat field_reprs, ', '}}"
+
+class Field
+  new: (@name, @type) =>
+
+  __tostring: =>
+    "#{@name}: #{@type}"
+
+class Set
+  new: (@elem_type) =>
+
+  __tostring: =>
+    "{#{@elem_type}}"
+
+class Mapping
+  new: (@in_type, @out_type) =>
+
+  __tostring: =>
+    "{#{@in_type} -> #{@out_type}}"
 
 class Function
   new: (@param_types, @return_types) =>
@@ -282,11 +398,11 @@ spec ->
         * type coroutine.create ->
       for simple_type in *simple_types
         expect_that (tokens simple_type), deep_eq {
-          Symbol T_NAME, Primitive simple_type
+          Symbol T_NAME, simple_type
         }
 
     it 'emits strucural tokens', ->
-      expect_that (tokens '(),{}[]->'), deep_eq {
+      expect_that (tokens '(),{}[]:->'), deep_eq {
         Symbol T_PAREN_OPEN
         Symbol T_PAREN_CLOSE
         Symbol T_COMMA
@@ -294,20 +410,21 @@ spec ->
         Symbol T_BRACE_CLOSE
         Symbol T_BRACKET_OPEN
         Symbol T_BRACKET_CLOSE
+        Symbol T_COLON
         Symbol T_ARROW
       }
 
     it 'ignores whitespace', ->
       expect_that (tokens ' (\tstring\r)\n-> string '), deep_eq {
         Symbol T_PAREN_OPEN
-        Symbol T_NAME, Primitive "string"
+        Symbol T_NAME, "string"
         Symbol T_PAREN_CLOSE
         Symbol T_ARROW
-        Symbol T_NAME, Primitive "string"
+        Symbol T_NAME, "string"
       }
 
     it 'rejects unrecognised characters', ->
-      expect_that (-> tokens '"'), errors matches [[unrecognised character '"']]
+      expect_that (-> tokens '@'), errors matches [[unrecognised character '@']]
       expect_that (-> tokens '1'), errors matches [[unrecognised character '1']]
 
     describe ':peek', ->
@@ -354,6 +471,22 @@ spec ->
           Primitive 'string',
           Tuple { (UserType 'Custom'), (Primitive 'table') },
         }
+
+      it 'accepts sets', ->
+        expect_that (parse '{string}'), deep_eq Set Primitive 'string'
+        expect_that (parse '{{string}}'), deep_eq Set Set Primitive 'string'
+
+      it 'accepts mappings', ->
+        expect_that (parse '{boolean -> number}'), deep_eq Mapping (Primitive 'boolean'), Primitive 'number'
+        expect_that (parse '{{boolean -> number} -> {string -> thread}}'), deep_eq Mapping (Mapping (Primitive 'boolean'), Primitive 'number'), Mapping (Primitive 'string'), Primitive 'thread'
+
+      it 'accepts structs', ->
+        expect_that (parse '{}'), deep_eq Struct {}
+        expect_that (parse '{field: boolean}'), deep_eq Struct
+          * Field 'field', Primitive 'boolean'
+        expect_that (parse '{field1: number, field2: string}'), deep_eq Struct
+          * Field 'field1', Primitive 'number'
+          * Field 'field2', Primitive 'string'
 
   describe 'declare_type', ->
     it 'rejects false primitives', ->

--- a/spec.yue
+++ b/spec.yue
@@ -557,12 +557,13 @@ export repr = =>
             [] = '{'
             first = true
             keys = [ key for key, _ in pairs @ ]
-            table.sort keys, (a, b) ->
-              ta = type a
-              tb = type b
-              if ta != tb or ta == 'number'
-                return false
-              a < b
+            if can_sort keys
+              table.sort keys, (a, b) ->
+                ta = type a
+                tb = type b
+                if ta != tb or ta == 'number'
+                  return false
+                a < b
             for key in *keys
               value = @[key]
               if not first
@@ -589,6 +590,18 @@ is_list = (table) ->
     if max_key < k
       max_key = k
   max_key == num_keys and num_keys > 0
+
+can_sort = (list) ->
+  for elem in *list
+    switch type elem
+      when 'boolean', 'string', 'number'
+        continue
+      when 'table'
+        if not table.<>? or not table.<lt>?
+          return false
+      else
+        return false
+  true
 
 export matchers =
   anything: -> Anything!


### PR DESCRIPTION
This PR adds a new typechecker module, 'quicktype', which:

- Exports a function `T` which takes a _type spec_ and a value and asserts that the value implements the type spec
- Exports a function `F` which takes a type spec and a function and asserts that all values entering / exiting that function have the right types
- Exports a function `declare_type` to allow custom named type specs to be declared
- Supports recursive type checking
